### PR TITLE
chore(rpm): add nfpm configuration and build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 # Leger Project Makefile
 
+# Project configuration
+PROJECT := leger
+MODULE := github.com/leger-labs/leger
+
 # Version info
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+VERSION_SHORT := $(shell echo $(VERSION) | sed 's/^v//')
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
@@ -12,13 +17,23 @@ CGO_ENABLED ?= 0
 
 # ldflags for version embedding
 LDFLAGS := -ldflags "\
-	-X github.com/leger-labs/leger/internal/version.Version=$(VERSION) \
-	-X github.com/leger-labs/leger/internal/version.Commit=$(COMMIT) \
-	-X github.com/leger-labs/leger/internal/version.BuildDate=$(BUILD_DATE) \
+	-X $(MODULE)/internal/version.Version=$(VERSION) \
+	-X $(MODULE)/internal/version.Commit=$(COMMIT) \
+	-X $(MODULE)/internal/version.BuildDate=$(BUILD_DATE) \
 	-w -s"
 
 # Build flags
 BUILD_FLAGS := -trimpath $(LDFLAGS)
+
+# Package settings
+RPM_ARCH := $(GOARCH)
+ifeq ($(GOARCH),amd64)
+	RPM_ARCH := x86_64
+endif
+ifeq ($(GOARCH),arm64)
+	RPM_ARCH := aarch64
+endif
+RPM_FILE := $(PROJECT)-$(VERSION_SHORT)-1.$(RPM_ARCH).rpm
 
 .PHONY: help
 help: ## Show this help
@@ -47,12 +62,91 @@ lint: ## Run linters
 
 .PHONY: clean
 clean: ## Clean build artifacts
-	rm -f leger legerd *.rpm
+	rm -f leger legerd leger-* legerd-*
+	rm -f *.rpm *.deb
 	rm -rf dist/
+	rm -f nfpm-build.yaml
+
+.PHONY: rpm
+rpm: build-leger build-legerd ## Build RPM package for current GOARCH
+	@echo "Building RPM for $(GOARCH) ($(RPM_ARCH))..."
+	@command -v nfpm >/dev/null 2>&1 || { \
+		echo "ERROR: nfpm not found. Install it:"; \
+		echo "  go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest"; \
+		exit 1; \
+	}
+	@# Set environment variables and build
+	VERSION=$(VERSION_SHORT) \
+	RPM_ARCH=$(RPM_ARCH) \
+	CLI_BINARY=leger \
+	DAEMON_BINARY=legerd \
+	nfpm pkg --packager rpm -f nfpm.yaml
+	@echo "Created: $(RPM_FILE)"
+
+.PHONY: rpm-all
+rpm-all: ## Build RPMs for all architectures
+	@$(MAKE) rpm GOARCH=amd64
+	@$(MAKE) rpm GOARCH=arm64
+	@echo "Created RPMs for amd64 and arm64"
+
+.PHONY: install-rpm
+install-rpm: rpm ## Build and install RPM locally
+	@echo "Installing RPM..."
+	sudo dnf install -y ./$(RPM_FILE)
+	@echo "Installed. Configure and start:"
+	@echo "  systemctl enable --now legerd.service          # System-wide"
+	@echo "  systemctl --user enable --now legerd.service   # Per-user"
+
+.PHONY: uninstall-rpm
+uninstall-rpm: ## Uninstall RPM package
+	sudo dnf remove -y $(PROJECT)
+
+.PHONY: sign
+sign: ## Sign RPM packages with GPG (Usage: make sign GPG_KEY=your@email.com)
+	@command -v rpmsign >/dev/null 2>&1 || { \
+		echo "ERROR: rpmsign not found. Install: sudo dnf install rpm-sign"; \
+		exit 1; \
+	}
+	@if [ -z "$(GPG_KEY)" ]; then \
+		echo "ERROR: GPG_KEY not set. Usage: make sign GPG_KEY=your@email.com"; \
+		exit 1; \
+	fi
+	@for rpm in $(PROJECT)-*.rpm; do \
+		if [ -f "$$rpm" ]; then \
+			echo "Signing $$rpm..."; \
+			rpmsign --addsign --key-id=$(GPG_KEY) $$rpm; \
+		fi; \
+	done
+
+.PHONY: verify
+verify: ## Verify RPM signatures
+	@for rpm in $(PROJECT)-*.rpm; do \
+		if [ -f "$$rpm" ]; then \
+			echo "Verifying $$rpm..."; \
+			rpm --checksig $$rpm; \
+		fi; \
+	done
+
+.PHONY: version
+version: ## Show version information
+	@echo "Version:    $(VERSION)"
+	@echo "Short:      $(VERSION_SHORT)"
+	@echo "Commit:     $(COMMIT)"
+	@echo "Build Date: $(BUILD_DATE)"
+	@echo "GOOS:       $(GOOS)"
+	@echo "GOARCH:     $(GOARCH)"
+	@echo "RPM Arch:   $(RPM_ARCH)"
 
 .PHONY: dev
 dev: build ## Quick build and test
 	./leger --version || echo "leger CLI placeholder"
 	./legerd --version
+
+.PHONY: setup-dev
+setup-dev: ## Install development dependencies
+	@echo "Installing development tools..."
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+	@echo "Development tools installed."
 
 .DEFAULT_GOAL := help

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,132 @@
+# nfpm configuration for leger
+# Packages both the CLI (leger) and daemon (legerd)
+# Based on Tailscale's dual-binary approach
+
+name: "leger"
+arch: "${RPM_ARCH}"
+platform: "linux"
+version: "${VERSION}"
+release: 1
+section: "default"
+priority: "extra"
+
+# Package metadata
+maintainer: "leger Team <packages@leger.run>"
+description: |
+  leger - Podman Quadlet Manager
+
+  Manages Podman Quadlets from Git repositories with secure
+  secret management via Setec integration.
+
+  This package includes:
+  - leger: Interactive CLI for managing quadlets
+  - legerd: Background daemon for continuous sync
+
+  Features:
+  - Declarative Quadlet management from Git
+  - Automatic updates with rollback capability
+  - Secure secrets via Setec
+  - Support for both user and system services
+
+homepage: "https://leger.run"
+license: "MIT"
+vendor: "leger Project"
+
+# File contents
+contents:
+  # CLI binary
+  - src: "./${CLI_BINARY}"
+    dst: "/usr/bin/leger"
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
+  # Daemon binary
+  - src: "./${DAEMON_BINARY}"
+    dst: "/usr/bin/legerd"
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
+  # Systemd units - user scope
+  - src: "./systemd/legerd.service"
+    dst: "/usr/lib/systemd/user/legerd.service"
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  # Systemd units - system scope
+  - src: "./systemd/legerd@.service"
+    dst: "/usr/lib/systemd/system/legerd.service"
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  # Environment file for system service
+  - src: "./systemd/legerd.default"
+    dst: "/etc/default/legerd"
+    type: config
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  # Default configuration (marked as config file)
+  - src: "./config/leger.yaml"
+    dst: "/etc/leger/config.yaml"
+    type: config
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
+  # Data directories
+  - dst: "/var/lib/legerd"
+    type: dir
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
+  - dst: "/var/lib/legerd/staged"
+    type: dir
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
+  - dst: "/var/lib/legerd/backups"
+    type: dir
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
+# RPM-specific scriptlets
+scripts:
+  postinstall: "./release/rpm/postinst.sh"
+  preremove: "./release/rpm/prerm.sh"
+  postremove: "./release/rpm/postrm.sh"
+
+# Package dependencies
+depends:
+  - "systemd"
+
+# Recommended packages (not required)
+recommends:
+  - "podman >= 4.0"
+  - "git"
+
+# RPM-specific configuration
+rpm:
+  group: "System Environment/Daemons"
+  summary: "Podman Quadlet manager with Git and Setec integration"
+  compression: "xz"
+
+  # Package signing (if configured)
+  signature:
+    key_file: "${GPG_KEY_FILE}"

--- a/release/rpm/postinst.sh
+++ b/release/rpm/postinst.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# RPM postinstall script for leger
+# Based on Tailscale's rpm.postinst.sh pattern
+#
+# RPM scriptlet parameters:
+# $1 == 1 for initial installation
+# $1 == 2 for upgrades
+
+if [ $1 -eq 1 ]; then
+    # Initial installation
+
+    # Create runtime and state directories if they don't exist
+    mkdir -p /var/lib/legerd/staged
+    mkdir -p /var/lib/legerd/backups
+    mkdir -p /run/legerd
+
+    # Set proper permissions
+    chmod 755 /var/lib/legerd
+    chmod 755 /var/lib/legerd/staged
+    chmod 755 /var/lib/legerd/backups
+    chmod 755 /run/legerd
+
+    # Reload systemd to pick up new units
+    systemctl daemon-reload >/dev/null 2>&1 || :
+
+    # Follow RPM convention: use systemd preset policy
+    # Don't auto-enable unless administrator has configured a preset
+    systemctl preset legerd.service >/dev/null 2>&1 || :
+
+    echo ""
+    echo "leger installed successfully."
+    echo ""
+    echo "To start:"
+    echo "  systemctl enable --now legerd.service    # System-wide"
+    echo "  systemctl --user enable --now legerd.service  # Per-user"
+    echo ""
+    echo "Configuration: /etc/leger/config.yaml"
+    echo "Documentation: https://leger.run/docs/"
+    echo ""
+fi
+
+# For upgrades ($1 == 2), daemon-reload happens in postrm
+# This matches Tailscale's pattern

--- a/release/rpm/postrm.sh
+++ b/release/rpm/postrm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# RPM post-removal script for leger
+# Based on Tailscale's rpm.postrm.sh
+#
+# RPM scriptlet parameters:
+# $1 == 0 for uninstallation
+# $1 == 1 for removing old package during upgrade
+
+# Always reload systemd daemon after package changes
+systemctl daemon-reload >/dev/null 2>&1 || :
+
+if [ $1 -ge 1 ]; then
+    # Package upgrade, not uninstall
+    # Restart the service if it was running
+    # This is the seamless upgrade pattern
+    systemctl try-restart legerd.service >/dev/null 2>&1 || :
+fi
+
+# For full uninstall ($1 == 0), services are already stopped by prerm
+# Just inform the user about leftover data
+if [ $1 -eq 0 ]; then
+    echo ""
+    echo "leger has been removed."
+    echo "Data preserved in: /var/lib/legerd"
+    echo "To remove all data: sudo rm -rf /var/lib/legerd /etc/leger"
+    echo ""
+fi

--- a/release/rpm/prerm.sh
+++ b/release/rpm/prerm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# RPM pre-removal script for leger
+# Based on Tailscale's rpm.prerm.sh
+#
+# RPM scriptlet parameters:
+# $1 == 0 for uninstallation
+# $1 == 1 for removing old package during upgrade
+
+if [ $1 -eq 0 ]; then
+    # Package removal (not upgrade) - stop and disable services
+
+    # Stop and disable system service
+    systemctl --no-reload disable legerd.service >/dev/null 2>&1 || :
+    systemctl stop legerd.service >/dev/null 2>&1 || :
+fi
+
+# For upgrades ($1 == 1), we don't stop the service
+# It will be restarted by postrm after the new version is installed
+# This matches Tailscale's pattern for seamless upgrades


### PR DESCRIPTION
## Summary

Implements Issue #3 - RPM packaging for leger and legerd binaries.

## Changes

- Add nfpm.yaml configuration for dual-binary RPM packaging
- Add RPM scriptlets (postinst, prerm, postrm) in release/rpm/
- Update Makefile with RPM build targets:
  - rpm: Build RPM for current architecture
  - rpm-all: Build RPMs for amd64 and arm64
  - install-rpm: Build and install locally
  - uninstall-rpm: Remove package
  - sign/verify: GPG signing support
- Add version stamping with proper RPM architecture mapping
- Follow Tailscale's battle-tested RPM packaging approach

The configuration packages both binaries with systemd units for user and system scope, includes proper upgrade/downgrade handling, and preserves state on uninstall for rollback support.

## Testing

- [x] Makefile syntax validated
- [x] Version stamping working
- [ ] RPM build requires nfpm installation
- [ ] Integration testing with `make rpm`
- [ ] Installation testing on Fedora

## References

- Closes #8
- Based on `/docs/rpm-packaging/RPM-PACKAGING.md`
- Reference: `/docs/rpm-packaging/nfpm-dual.yaml`

---

Generated with [Claude Code](https://claude.com/claude-code)