### PR TITLE
feat(cli): implement Cobra CLI structure

### DIFF
--- a/cmd/leger/auth.go
+++ b/cmd/leger/auth.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// authCmd returns the auth command group
+func authCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Authentication commands",
+		Long:  "Manage Leger authentication and Tailscale identity verification",
+	}
+
+	cmd.AddCommand(authLoginCmd())
+	cmd.AddCommand(authStatusCmd())
+	cmd.AddCommand(authLogoutCmd())
+
+	return cmd
+}
+
+// authLoginCmd returns the auth login command
+func authLoginCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate with Leger Labs",
+		Long: `Verify Tailscale identity and authenticate with Leger.
+
+This command checks your existing Tailscale authentication and uses it
+to authenticate with Leger Labs. No separate login is required.
+
+Requirements:
+- Tailscale must be installed
+- Tailscale must be running (tailscale up)
+- Device must be authenticated to a Tailnet`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}
+
+// authStatusCmd returns the auth status command
+func authStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Check authentication status",
+		Long: `Display current authentication status and Tailscale identity.
+
+Shows whether you are authenticated with Leger Labs and displays
+your Tailscale identity information.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}
+
+// authLogoutCmd returns the auth logout command
+func authLogoutCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Log out of Leger Labs",
+		Long: `Clear Leger authentication credentials.
+
+This removes your stored Leger authentication but does not affect
+your Tailscale authentication.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}

--- a/cmd/leger/config.go
+++ b/cmd/leger/config.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// configCmd returns the config command group
+func configCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Configuration management",
+		Long:  "Manage Leger configuration and deployment settings",
+	}
+
+	cmd.AddCommand(configPullCmd())
+	cmd.AddCommand(configShowCmd())
+
+	return cmd
+}
+
+// configPullCmd returns the config pull command
+func configPullCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "pull",
+		Short: "Pull configuration from backend",
+		Long: `Fetch configuration from Leger backend.
+
+Downloads the latest configuration from the Leger Labs backend
+and updates the local configuration file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}
+
+// configShowCmd returns the config show command
+func configShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Display current configuration",
+		Long: `Show the current Leger configuration.
+
+Displays the active configuration including deployment settings,
+repository locations, and legerd connection details.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}

--- a/cmd/leger/deploy.go
+++ b/cmd/leger/deploy.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// deployCmd returns the deploy command group
+func deployCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Deployment commands",
+		Long:  "Manage Podman Quadlet deployments from Git repositories",
+	}
+
+	cmd.AddCommand(deployInitCmd())
+	cmd.AddCommand(deployUpdateCmd())
+
+	return cmd
+}
+
+// deployInitCmd returns the deploy init command
+func deployInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Initialize deployment",
+		Long: `Initialize a new Leger deployment.
+
+Sets up the local deployment environment, clones the quadlet
+repository, and prepares systemd units for activation.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}
+
+// deployUpdateCmd returns the deploy update command
+func deployUpdateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update",
+		Short: "Update deployed services",
+		Long: `Update deployed Podman Quadlets.
+
+Pulls the latest changes from the Git repository, updates
+systemd units, and restarts affected services.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}

--- a/cmd/leger/main.go
+++ b/cmd/leger/main.go
@@ -1,7 +1,39 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+
+	"github.com/tailscale/setec/internal/version"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "leger",
+	Short: "Podman Quadlet Manager with Secrets",
+	Long: `Leger manages Podman Quadlets from Git repositories with integrated
+secrets management via legerd.`,
+	Version: version.String(),
+}
+
+func init() {
+	rootCmd.SetVersionTemplate(version.Long() + "\n")
+
+	// Global flags
+	rootCmd.PersistentFlags().StringP("config", "c", "", "config file (default: /etc/leger/config.yaml)")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
+
+	// Command groups
+	rootCmd.AddCommand(authCmd())
+	rootCmd.AddCommand(configCmd())
+	rootCmd.AddCommand(deployCmd())
+	rootCmd.AddCommand(secretsCmd())
+	rootCmd.AddCommand(statusCmd())
+}
 
 func main() {
-	fmt.Println("leger CLI - coming soon")
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/cmd/leger/secrets.go
+++ b/cmd/leger/secrets.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// secretsCmd returns the secrets command group
+func secretsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secrets",
+		Short: "Secrets management",
+		Long:  "Manage secrets via legerd daemon",
+	}
+
+	cmd.AddCommand(secretsSyncCmd())
+	cmd.AddCommand(secretsListCmd())
+
+	return cmd
+}
+
+// secretsSyncCmd returns the secrets sync command
+func secretsSyncCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sync",
+		Short: "Sync secrets from backend",
+		Long: `Synchronize secrets from legerd daemon.
+
+Fetches the latest secrets from legerd and updates the local
+secret store for use by Podman Quadlets.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}
+
+// secretsListCmd returns the secrets list command
+func secretsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List available secrets",
+		Long: `Display all available secrets.
+
+Shows secrets that are available from legerd for use in
+your Podman Quadlet deployments.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}

--- a/cmd/leger/status.go
+++ b/cmd/leger/status.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// statusCmd returns the status command
+func statusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show overall system status",
+		Long: `Display comprehensive Leger system status.
+
+Shows the status of:
+- Authentication with Leger Labs
+- legerd daemon connection
+- Deployed Podman Quadlets
+- Git repository sync status`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/illarion/gonotify/v3 v3.0.2 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jsimonetti/rtnetlink v1.4.0 // indirect
@@ -78,6 +79,8 @@ require (
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/safchain/ethtool v0.3.0 // indirect
+	github.com/spf13/cobra v1.10.1 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tailscale/certstore v0.1.1-0.20231202035212-d3fa0460f47e // indirect
 	github.com/tailscale/go-winio v0.0.0-20231025203758-c4f33415bf55 // indirect
 	github.com/tailscale/goupnp v1.0.1-0.20210804011211-c64d0f06ea05 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NA
 github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 h1:8h5+bWd7R6AYUslN6c6iuZWTKsKxUFDlpnmilO6R2n0=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creachadair/command v0.1.22 h1:WmdrURwZdmPD1jm13SjKooaMoqo7mW1qI2BPCShs154=
 github.com/creachadair/command v0.1.22/go.mod h1:YFc+OMGucqTpxwQg/iJnNg8BMNmRPDK60rYy8ckgKwE=
 github.com/creachadair/flax v0.0.4 h1:6JYUw/MK85Tw9f99n1PBBfLWYrxQkfrgWP4A6zf4XhE=
@@ -117,6 +118,8 @@ github.com/hdevalence/ed25519consensus v0.2.0 h1:37ICyZqdyj0lAZ8P4D1d1id3HqbbG1N
 github.com/hdevalence/ed25519consensus v0.2.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
 github.com/illarion/gonotify/v3 v3.0.2 h1:O7S6vcopHexutmpObkeWsnzMJt/r1hONIEogeVNmJMk=
 github.com/illarion/gonotify/v3 v3.0.2/go.mod h1:HWGPdPe817GfvY3w7cx6zkbzNZfi3QjcBm/wgVvEL1U=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2 h1:9K06NfxkBh25x56yVhWWlKFE8YpicaSfHwoV8SFbueA=
 github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2/go.mod h1:3A9PQ1cunSDF/1rbTq99Ts4pVnycWg+vlPkfeD2NLFI=
 github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
@@ -173,8 +176,14 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP0=
 github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=


### PR DESCRIPTION
## Summary

Implements the complete Cobra CLI structure for Leger as specified in `backlog/issue-5-cobra-cli.md`.

## Changes

- Added Cobra dependency (v1.10.1)
- Rewrote `cmd/leger/main.go` with full Cobra structure
- Created command stub files:
  - `auth.go`: login, status, logout commands
  - `config.go`: pull, show commands
  - `deploy.go`: init, update commands
  - `secrets.go`: sync, list commands
  - `status.go`: overall system status
- Wired up version information from `internal/version`
- Added comprehensive help text for all commands
- All commands return "not yet implemented"
- Global flags: `--config`, `--verbose`

## Testing

- [x] Build succeeds: `go build -o leger ./cmd/leger`
- [x] Help system works: `leger --help`, `leger auth --help`
- [x] Version correct: `./leger --version`
- [x] All commands return "not yet implemented"
- [x] Global flags work
- [x] No crashes or panics

Resolves #10

---

Generated with [Claude Code](https://claude.ai/code)