### PR TITLE
feat(cli): implement auth commands with local storage

### DIFF
--- a/cmd/leger/auth.go
+++ b/cmd/leger/auth.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/tailscale/setec/internal/auth"
 	"github.com/tailscale/setec/internal/tailscale"
 )
 
@@ -29,18 +31,34 @@ func authLoginCmd() *cobra.Command {
 		Short: "Authenticate with Leger Labs",
 		Long: `Verify Tailscale identity and authenticate with Leger.
 
-This command checks your existing Tailscale authentication and uses it
-to authenticate with Leger Labs. No separate login is required.
+This command checks your existing Tailscale authentication and uses it to
+authenticate with Leger. No separate login is required.
 
 Requirements:
 - Tailscale must be installed
 - Tailscale must be running (tailscale up)
-- Device must be authenticated to a Tailnet`,
+- Device must be authenticated to a Tailnet
+
+Your Tailscale identity will be stored locally in:
+  ~/.config/leger/auth.json
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			fmt.Println("Authenticating with Leger Labs...")
+			fmt.Println("Authenticating with Leger...")
 			fmt.Println()
+
+			// Check if already authenticated
+			if auth.IsAuthenticated() {
+				currentAuth, _ := auth.Load()
+				fmt.Println("✓ Already authenticated")
+				fmt.Printf("  User:      %s\n", currentAuth.TailscaleUser)
+				fmt.Printf("  Tailnet:   %s\n", currentAuth.Tailnet)
+				fmt.Printf("  Device:    %s\n", currentAuth.DeviceName)
+				fmt.Println()
+				fmt.Println("Run 'leger auth logout' to clear authentication")
+				return nil
+			}
 
 			// Verify Tailscale identity
 			client := tailscale.NewClient()
@@ -54,10 +72,27 @@ Requirements:
 			fmt.Printf("  User:      %s\n", identity.LoginName)
 			fmt.Printf("  Tailnet:   %s\n", identity.Tailnet)
 			fmt.Printf("  Device:    %s\n", identity.DeviceName)
+			fmt.Printf("  IP:        %s\n", identity.DeviceIP)
 			fmt.Println()
 
-			// TODO: Authenticate with Leger backend (Issue #8)
-			fmt.Println("✓ Authenticated with Leger Labs")
+			// Save authentication
+			authState := &auth.Auth{
+				TailscaleUser:   identity.LoginName,
+				Tailnet:         identity.Tailnet,
+				DeviceName:      identity.DeviceName,
+				DeviceIP:        identity.DeviceIP,
+				AuthenticatedAt: time.Now(),
+			}
+
+			if err := authState.Save(); err != nil {
+				return fmt.Errorf("failed to save authentication: %w", err)
+			}
+
+			authFile, _ := auth.AuthFile()
+			fmt.Println("✓ Authentication saved")
+			fmt.Printf("  Location:  %s\n", authFile)
+			fmt.Println()
+			fmt.Println("You're now authenticated with Leger!")
 
 			return nil
 		},
@@ -69,40 +104,71 @@ func authStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Check authentication status",
-		Long: `Display current authentication status and Tailscale identity.
-
-Shows whether you are authenticated with Leger Labs and displays
-your Tailscale identity information.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			// Check Tailscale status
 			client := tailscale.NewClient()
 
+			fmt.Println("=== Tailscale Status ===")
+			fmt.Println()
+
 			if !client.IsInstalled() {
-				fmt.Println("Tailscale: not installed")
+				fmt.Println("Status: NOT INSTALLED")
+				fmt.Println()
+				fmt.Println("Install Tailscale from: https://tailscale.com/download")
 				return fmt.Errorf("Tailscale not installed")
 			}
 
 			if !client.IsRunning(ctx) {
-				fmt.Println("Tailscale: not running")
+				fmt.Println("Status: NOT RUNNING")
+				fmt.Println()
+				fmt.Println("Start Tailscale: sudo tailscale up")
 				return fmt.Errorf("Tailscale daemon not running")
 			}
 
 			identity, err := client.GetIdentity(ctx)
 			if err != nil {
+				fmt.Println("Status: ERROR")
 				return err
 			}
 
-			fmt.Println("Tailscale: authenticated")
+			fmt.Println("Status: AUTHENTICATED")
 			fmt.Printf("  User:      %s\n", identity.LoginName)
 			fmt.Printf("  Tailnet:   %s\n", identity.Tailnet)
 			fmt.Printf("  Device:    %s\n", identity.DeviceName)
+			fmt.Printf("  IP:        %s\n", identity.DeviceIP)
 			fmt.Println()
 
-			// TODO: Check Leger backend authentication (Issue #8)
-			fmt.Println("Leger Labs: not authenticated")
-			fmt.Println("Run: leger auth login")
+			// Check Leger authentication
+			fmt.Println("=== Leger Authentication ===")
+			fmt.Println()
+
+			authState, err := auth.Load()
+			if err != nil {
+				fmt.Println("Status: ERROR")
+				return fmt.Errorf("failed to load auth: %w", err)
+			}
+
+			if authState == nil {
+				fmt.Println("Status: NOT AUTHENTICATED")
+				fmt.Println()
+				fmt.Println("Run: leger auth login")
+				return nil
+			}
+
+			fmt.Println("Status: AUTHENTICATED")
+			fmt.Printf("  User:      %s\n", authState.TailscaleUser)
+			fmt.Printf("  Tailnet:   %s\n", authState.Tailnet)
+			fmt.Printf("  Device:    %s\n", authState.DeviceName)
+			fmt.Printf("  Authenticated: %s\n", authState.AuthenticatedAt.Format("2006-01-02 15:04:05"))
+			fmt.Println()
+
+			// Verify identity matches
+			if authState.TailscaleUser != identity.LoginName {
+				fmt.Println("⚠ Warning: Tailscale identity has changed")
+				fmt.Println("  Run 'leger auth login' to re-authenticate")
+			}
 
 			return nil
 		},
@@ -113,13 +179,27 @@ your Tailscale identity information.`,
 func authLogoutCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "logout",
-		Short: "Log out of Leger Labs",
-		Long: `Clear Leger authentication credentials.
-
-This removes your stored Leger authentication but does not affect
-your Tailscale authentication.`,
+		Short: "Log out of Leger",
+		Long:  "Clear local authentication state. Tailscale authentication is not affected.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("not yet implemented")
+			if !auth.IsAuthenticated() {
+				fmt.Println("Not authenticated")
+				return nil
+			}
+
+			currentAuth, _ := auth.Load()
+
+			if err := auth.Clear(); err != nil {
+				return fmt.Errorf("failed to clear authentication: %w", err)
+			}
+
+			fmt.Println("✓ Logged out successfully")
+			fmt.Printf("  User:      %s\n", currentAuth.TailscaleUser)
+			fmt.Println()
+			fmt.Println("Tailscale authentication is still active.")
+			fmt.Println("Run 'leger auth login' to authenticate again.")
+
+			return nil
 		},
 	}
 }

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Auth represents stored authentication state
+type Auth struct {
+	TailscaleUser   string    `json:"tailscale_user"`
+	Tailnet         string    `json:"tailnet"`
+	DeviceName      string    `json:"device_name"`
+	DeviceIP        string    `json:"device_ip"`
+	AuthenticatedAt time.Time `json:"authenticated_at"`
+}
+
+// AuthFile returns the path to the auth file
+func AuthFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	configDir := filepath.Join(home, ".config", "leger")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return "", fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	return filepath.Join(configDir, "auth.json"), nil
+}
+
+// Save saves authentication state to disk
+func (a *Auth) Save() error {
+	path, err := AuthFile()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal auth: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write auth file: %w", err)
+	}
+
+	return nil
+}
+
+// Load loads authentication state from disk
+func Load() (*Auth, error) {
+	path, err := AuthFile()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // Not authenticated
+		}
+		return nil, fmt.Errorf("failed to read auth file: %w", err)
+	}
+
+	var auth Auth
+	if err := json.Unmarshal(data, &auth); err != nil {
+		return nil, fmt.Errorf("failed to parse auth file: %w", err)
+	}
+
+	return &auth, nil
+}
+
+// Clear removes authentication state
+func Clear() error {
+	path, err := AuthFile()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil // Already cleared
+		}
+		return fmt.Errorf("failed to remove auth file: %w", err)
+	}
+
+	return nil
+}
+
+// IsAuthenticated checks if user is authenticated
+func IsAuthenticated() bool {
+	auth, err := Load()
+	return err == nil && auth != nil
+}

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -1,0 +1,151 @@
+package auth
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestAuthSaveLoad(t *testing.T) {
+	// Clean up before and after
+	defer Clear()
+
+	// Create test auth
+	testAuth := &Auth{
+		TailscaleUser:   "alice@example.ts.net",
+		Tailnet:         "example.ts.net",
+		DeviceName:      "test-device",
+		DeviceIP:        "100.64.0.1",
+		AuthenticatedAt: time.Now().Truncate(time.Second),
+	}
+
+	// Save
+	if err := testAuth.Save(); err != nil {
+		t.Fatalf("failed to save auth: %v", err)
+	}
+
+	// Load
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("failed to load auth: %v", err)
+	}
+
+	if loaded == nil {
+		t.Fatal("expected non-nil auth")
+	}
+
+	if loaded.TailscaleUser != testAuth.TailscaleUser {
+		t.Errorf("expected %s, got %s", testAuth.TailscaleUser, loaded.TailscaleUser)
+	}
+
+	if loaded.Tailnet != testAuth.Tailnet {
+		t.Errorf("expected %s, got %s", testAuth.Tailnet, loaded.Tailnet)
+	}
+
+	if loaded.DeviceName != testAuth.DeviceName {
+		t.Errorf("expected %s, got %s", testAuth.DeviceName, loaded.DeviceName)
+	}
+
+	if loaded.DeviceIP != testAuth.DeviceIP {
+		t.Errorf("expected %s, got %s", testAuth.DeviceIP, loaded.DeviceIP)
+	}
+}
+
+func TestClear(t *testing.T) {
+	// Clean up after
+	defer Clear()
+
+	// Create test auth
+	testAuth := &Auth{
+		TailscaleUser: "alice@example.ts.net",
+		Tailnet:       "example.ts.net",
+		DeviceName:    "test-device",
+		DeviceIP:      "100.64.0.1",
+	}
+	if err := testAuth.Save(); err != nil {
+		t.Fatalf("failed to save auth: %v", err)
+	}
+
+	// Clear
+	if err := Clear(); err != nil {
+		t.Fatalf("failed to clear: %v", err)
+	}
+
+	// Verify cleared
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("failed to load after clear: %v", err)
+	}
+	if loaded != nil {
+		t.Fatal("expected nil after clear")
+	}
+}
+
+func TestIsAuthenticated(t *testing.T) {
+	// Clean up before and after
+	defer Clear()
+
+	// Initially not authenticated
+	if IsAuthenticated() {
+		t.Fatal("expected not authenticated initially")
+	}
+
+	// Save auth
+	testAuth := &Auth{
+		TailscaleUser: "alice@example.ts.net",
+		Tailnet:       "example.ts.net",
+		DeviceName:    "test-device",
+		DeviceIP:      "100.64.0.1",
+	}
+	if err := testAuth.Save(); err != nil {
+		t.Fatalf("failed to save auth: %v", err)
+	}
+
+	// Now authenticated
+	if !IsAuthenticated() {
+		t.Fatal("expected authenticated after save")
+	}
+
+	// Clear
+	if err := Clear(); err != nil {
+		t.Fatalf("failed to clear: %v", err)
+	}
+
+	// Not authenticated again
+	if IsAuthenticated() {
+		t.Fatal("expected not authenticated after clear")
+	}
+}
+
+func TestAuthFilePermissions(t *testing.T) {
+	// Clean up after
+	defer Clear()
+
+	// Save auth
+	testAuth := &Auth{
+		TailscaleUser: "alice@example.ts.net",
+		Tailnet:       "example.ts.net",
+		DeviceName:    "test-device",
+		DeviceIP:      "100.64.0.1",
+	}
+	if err := testAuth.Save(); err != nil {
+		t.Fatalf("failed to save auth: %v", err)
+	}
+
+	// Get auth file path
+	path, err := AuthFile()
+	if err != nil {
+		t.Fatalf("failed to get auth file path: %v", err)
+	}
+
+	// Check file permissions
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat auth file: %v", err)
+	}
+
+	mode := info.Mode()
+	if mode.Perm() != 0600 {
+		t.Errorf("expected permissions 0600, got %o", mode.Perm())
+	}
+}


### PR DESCRIPTION
## Summary

Implements complete authentication workflow with login, status, and logout commands. Authentication is based on Tailscale identity stored locally at `~/.config/leger/auth.json`.

## Changes

- Add `internal/auth` package for authentication storage
- Implement Auth struct with Save/Load/Clear methods
- Add comprehensive tests for auth storage
- Update auth commands to use local storage
- Add auth file permissions validation (0600)
- Implement identity verification and status checking
- Add user-friendly error messages and help text

## Testing

- ✅ Unit tests pass: `go test ./internal/auth/`
- ✅ Build succeeds: `go build ./cmd/leger/`
- ✅ All commands have proper help text
- ✅ CLI integration working

Resolves #13

---

Generated with [Claude Code](https://claude.ai/code)