### PR TITLE
feat(cli): implement legerd HTTP client

### DIFF
--- a/cmd/leger/secrets.go
+++ b/cmd/leger/secrets.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/tailscale/setec/internal/daemon"
 	"github.com/spf13/cobra"
 )
 
@@ -25,12 +26,13 @@ func secretsSyncCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "sync",
 		Short: "Sync secrets from backend",
-		Long: `Synchronize secrets from legerd daemon.
+		Long: `Synchronize secrets from Leger backend and store in legerd.
 
-Fetches the latest secrets from legerd and updates the local
-secret store for use by Podman Quadlets.`,
+Fetches the latest secrets from Leger Labs and updates legerd
+for use by Podman Quadlets.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("not yet implemented")
+			// TODO: Implement in v0.2.0
+			return fmt.Errorf("not yet implemented - coming in v0.2.0")
 		},
 	}
 }
@@ -40,12 +42,36 @@ func secretsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List available secrets",
-		Long: `Display all available secrets.
+		Long: `Display all available secrets from legerd.
 
 Shows secrets that are available from legerd for use in
 your Podman Quadlet deployments.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("not yet implemented")
+			ctx := cmd.Context()
+
+			client := daemon.NewClient("")
+
+			// Check if legerd is running
+			if err := client.Health(ctx); err != nil {
+				return fmt.Errorf("legerd not running: %w\n\nStart legerd with:\n  systemctl --user start legerd.service\n\nOr check logs:\n  journalctl --user -u legerd.service -f", err)
+			}
+
+			secrets, err := client.ListSecrets(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to list secrets: %w", err)
+			}
+
+			if len(secrets) == 0 {
+				fmt.Println("No secrets found")
+				return nil
+			}
+
+			fmt.Println("Available secrets:")
+			for _, secret := range secrets {
+				fmt.Printf("  - %s\n", secret)
+			}
+
+			return nil
 		},
 	}
 }

--- a/cmd/leger/status.go
+++ b/cmd/leger/status.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/tailscale/setec/internal/daemon"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +20,33 @@ Shows the status of:
 - Deployed Podman Quadlets
 - Git repository sync status`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("not yet implemented")
+			ctx := cmd.Context()
+
+			fmt.Println("=== Leger System Status ===")
+			fmt.Println()
+
+			// Check legerd daemon
+			fmt.Println("=== legerd Daemon ===")
+			fmt.Println()
+
+			daemonClient := daemon.NewClient("")
+			if err := daemonClient.Health(ctx); err != nil {
+				fmt.Println("Status: NOT RUNNING")
+				fmt.Printf("  Error: %v\n", err)
+				fmt.Println()
+				fmt.Println("Start legerd:")
+				fmt.Println("  systemctl --user start legerd.service")
+			} else {
+				fmt.Println("Status: RUNNING")
+				fmt.Println("  URL: http://localhost:8080")
+				fmt.Println()
+			}
+
+			// TODO: Add Tailscale status (Issue #6)
+			// TODO: Add authentication status (Issue #8)
+			// TODO: Add deployed services status
+
+			return nil
 		},
 	}
 }

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -1,0 +1,148 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Client communicates with legerd daemon
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a new legerd client
+func NewClient(baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = "http://localhost:8080"
+	}
+
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Health checks if legerd is running
+func (c *Client) Health(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/health", nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("legerd not reachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("legerd health check failed: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// Secret represents a secret from legerd
+type Secret struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// GetSecret retrieves a secret from legerd
+func (c *Client) GetSecret(ctx context.Context, name string) (string, error) {
+	u := fmt.Sprintf("%s/api/get?name=%s", c.baseURL, url.QueryEscape(name))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", fmt.Errorf("secret not found: %s", name)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("legerd error: %d: %s", resp.StatusCode, string(body))
+	}
+
+	var secret Secret
+	if err := json.NewDecoder(resp.Body).Decode(&secret); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return secret.Value, nil
+}
+
+// PutSecret stores a secret in legerd
+func (c *Client) PutSecret(ctx context.Context, name, value string) error {
+	secret := Secret{
+		Name:  name,
+		Value: value,
+	}
+
+	body, err := json.Marshal(secret)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/put", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to put secret: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("legerd error: %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
+// ListSecrets returns all secret names
+func (c *Client) ListSecrets(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/api/list", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("legerd error: %d: %s", resp.StatusCode, string(body))
+	}
+
+	var secrets []string
+	if err := json.NewDecoder(resp.Body).Decode(&secrets); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return secrets, nil
+}

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -1,0 +1,169 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientCreation(t *testing.T) {
+	client := NewClient("")
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+
+	if client.baseURL != "http://localhost:8080" {
+		t.Errorf("expected default baseURL, got %s", client.baseURL)
+	}
+}
+
+func TestClientWithCustomURL(t *testing.T) {
+	client := NewClient("http://custom:9000")
+	if client.baseURL != "http://custom:9000" {
+		t.Errorf("expected custom baseURL, got %s", client.baseURL)
+	}
+}
+
+func TestHealth_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.Health(context.Background())
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestHealth_Failure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.Health(context.Background())
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestGetSecret_Success(t *testing.T) {
+	expectedSecret := Secret{
+		Name:  "test-secret",
+		Value: "test-value",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/get" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("name") != "test-secret" {
+			t.Errorf("unexpected name query param: %s", r.URL.Query().Get("name"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedSecret)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	value, err := client.GetSecret(context.Background(), "test-secret")
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if value != "test-value" {
+		t.Errorf("expected 'test-value', got %s", value)
+	}
+}
+
+func TestGetSecret_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	_, err := client.GetSecret(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestPutSecret_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/put" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != "POST" {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+
+		var secret Secret
+		if err := json.NewDecoder(r.Body).Decode(&secret); err != nil {
+			t.Errorf("failed to decode body: %v", err)
+		}
+		if secret.Name != "test-secret" || secret.Value != "test-value" {
+			t.Errorf("unexpected secret: %+v", secret)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.PutSecret(context.Background(), "test-secret", "test-value")
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestListSecrets_Success(t *testing.T) {
+	expectedSecrets := []string{"secret1", "secret2", "secret3"}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedSecrets)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	secrets, err := client.ListSecrets(context.Background())
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if len(secrets) != 3 {
+		t.Errorf("expected 3 secrets, got %d", len(secrets))
+	}
+	for i, secret := range secrets {
+		if secret != expectedSecrets[i] {
+			t.Errorf("expected %s, got %s", expectedSecrets[i], secret)
+		}
+	}
+}
+
+func TestListSecrets_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]string{})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	secrets, err := client.ListSecrets(context.Background())
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if len(secrets) != 0 {
+		t.Errorf("expected 0 secrets, got %d", len(secrets))
+	}
+}


### PR DESCRIPTION
## Summary

Implements HTTP client for leger CLI to communicate with legerd daemon. This enables the CLI to retrieve secrets from the local legerd instance.

## Changes

- Add `internal/daemon/client.go` with Health, GetSecret, PutSecret, and ListSecrets methods
- Add comprehensive tests in `internal/daemon/client_test.go`
- Update status command to check legerd daemon health
- Update secrets list command to query legerd for available secrets
- Secrets sync remains stubbed for v0.2.0

## Testing

- [x] Unit tests pass: `go test ./internal/daemon/...`
- [x] Build succeeds: `go build ./cmd/leger`
- [x] All 9 tests passing

Closes #12

----

Generated with [Claude Code](https://claude.ai/code)