### PR TITLE
fix(tests): resolve all linting issues and fix integration test binary path

### DIFF
--- a/cmd/leger/backup.go
+++ b/cmd/leger/backup.go
@@ -271,7 +271,7 @@ func confirmRestore() bool {
 	fmt.Print("This will stop all services and replace the current deployment. Continue? (y/N): ")
 
 	var response string
-	fmt.Scanln(&response)
+	_, _ = fmt.Scanln(&response)
 
 	response = strings.ToLower(strings.TrimSpace(response))
 	return response == "y" || response == "yes"

--- a/cmd/leger/service.go
+++ b/cmd/leger/service.go
@@ -130,7 +130,7 @@ func findHealthCheckForService(serviceName string) *health.HealthCheck {
 
 		// Search for the quadlet file
 		var foundPath string
-		filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		_ = filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return nil
 			}

--- a/cmd/leger/staged.go
+++ b/cmd/leger/staged.go
@@ -253,7 +253,7 @@ Stage updates first:
 			if !force {
 				fmt.Print("Apply these updates? [y/N]: ")
 				var response string
-				fmt.Scanln(&response)
+				_, _ = fmt.Scanln(&response)
 				if response != "y" && response != "Y" && response != "yes" {
 					fmt.Println("Update cancelled")
 					return nil
@@ -313,7 +313,7 @@ Current deployment remains unchanged.`,
 			// Prompt for confirmation
 			fmt.Printf("Discard staged updates for %s? [y/N]: ", deploymentName)
 			var response string
-			fmt.Scanln(&response)
+			_, _ = fmt.Scanln(&response)
 			if response != "y" && response != "Y" && response != "yes" {
 				fmt.Println("Cancelled")
 				return nil

--- a/cmd/legerd/legerd.go
+++ b/cmd/legerd/legerd.go
@@ -274,7 +274,7 @@ func runServer(env *command.Env) error {
 		log.Print("Signal received, stopping...")
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		hs.Shutdown(ctx)
+		_ = hs.Shutdown(ctx)
 	}()
 
 	if err := hs.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -303,7 +303,7 @@ func runList(env *command.Env) error {
 	}
 
 	tw := newTabWriter(os.Stdout)
-	io.WriteString(tw, "NAME\tACTIVE\tVERSIONS\n")
+	_, _ = io.WriteString(tw, "NAME\tACTIVE\tVERSIONS\n")
 	for _, s := range secrets {
 		vers := make([]string, 0, len(s.Versions))
 		for _, v := range s.Versions {
@@ -400,20 +400,20 @@ func runPut(env *command.Env, name string) error {
 		// Standard input is connected to a terminal; prompt the human to type or
 		// paste the value and require confirmation.
 		var err error
-		io.WriteString(os.Stdout, "Enter secret: ")
+		_, _ = io.WriteString(os.Stdout, "Enter secret: ")
 		os.Stdout.Sync()
 		value, err = term.ReadPassword(int(os.Stdin.Fd()))
-		io.WriteString(os.Stdout, "\n")
+		_, _ = io.WriteString(os.Stdout, "\n")
 		if err != nil {
 			return err
 		}
 		if len(value) == 0 && !putArgs.EmptyOK {
 			return errors.New("no secret provided, aborting")
 		}
-		io.WriteString(os.Stdout, "Confirm secret: ")
+		_, _ = io.WriteString(os.Stdout, "Confirm secret: ")
 		os.Stdout.Sync()
 		s2, err := term.ReadPassword(int(os.Stdin.Fd()))
-		io.WriteString(os.Stdout, "\n")
+		_, _ = io.WriteString(os.Stdout, "\n")
 		if err != nil {
 			return err
 		}

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/tailscale/setec/client/setec"
 	"github.com/tailscale/setec/setectest"
 )
 
@@ -52,8 +51,8 @@ func TestClientSetecIntegration(t *testing.T) {
 
 	t.Run("ListSecrets", func(t *testing.T) {
 		// Put a few test secrets
-		client.PutSecret(ctx, "secret1", []byte("value1"))
-		client.PutSecret(ctx, "secret2", []byte("value2"))
+		_, _ = client.PutSecret(ctx, "secret1", []byte("value1"))
+		_, _ = client.PutSecret(ctx, "secret2", []byte("value2"))
 
 		secrets, err := client.ListSecrets(ctx)
 		if err != nil {
@@ -67,7 +66,7 @@ func TestClientSetecIntegration(t *testing.T) {
 
 	t.Run("InfoSecret", func(t *testing.T) {
 		secretName := "info-test"
-		client.PutSecret(ctx, secretName, []byte("test"))
+		_, _ = client.PutSecret(ctx, secretName, []byte("test"))
 
 		info, err := client.InfoSecret(ctx, secretName)
 		if err != nil {
@@ -84,8 +83,8 @@ func TestClientSetecIntegration(t *testing.T) {
 
 	t.Run("NewStore", func(t *testing.T) {
 		// Put some test secrets
-		client.PutSecret(ctx, "store-secret1", []byte("value1"))
-		client.PutSecret(ctx, "store-secret2", []byte("value2"))
+		_, _ = client.PutSecret(ctx, "store-secret1", []byte("value1"))
+		_, _ = client.PutSecret(ctx, "store-secret2", []byte("value2"))
 
 		// Create store
 		store, err := client.NewStore(ctx, []string{"store-secret1", "store-secret2"})
@@ -104,7 +103,7 @@ func TestClientSetecIntegration(t *testing.T) {
 		}
 
 		// Test AllowLookup (dynamic discovery)
-		client.PutSecret(ctx, "dynamic-secret", []byte("dynamic-value"))
+		_, _ = client.PutSecret(ctx, "dynamic-secret", []byte("dynamic-value"))
 		dynamicSecret, err := store.LookupSecret(ctx, "dynamic-secret")
 		if err != nil {
 			t.Errorf("Store.LookupSecret() failed: %v", err)

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -5,18 +5,18 @@ import (
 	"fmt"
 	"os/exec"
 
-	"tailscale.com/client/tailscale"
+	"tailscale.com/client/local"
 )
 
 // Client wraps Tailscale LocalClient
 type Client struct {
-	lc *tailscale.LocalClient
+	lc *local.Client
 }
 
 // NewClient creates a new Tailscale client
 func NewClient() *Client {
 	return &Client{
-		lc: &tailscale.LocalClient{},
+		lc: &local.Client{},
 	}
 }
 

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -14,12 +14,14 @@ func ShowProgress(message string, task func() error) error {
 		progressbar.OptionSpinnerType(14),
 		progressbar.OptionFullWidth(),
 	)
-	defer bar.Finish()
+	defer func() {
+		_ = bar.Finish()
+	}()
 
 	// Start the progress bar spinning
 	go func() {
 		for {
-			bar.Add(1)
+			_ = bar.Add(1)
 		}
 	}()
 

--- a/server/server.go
+++ b/server/server.go
@@ -391,5 +391,5 @@ func serveJSON[REQ any, RESP any](s *Server, w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(bs)
+	_, _ = w.Write(bs)
 }

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -104,9 +104,9 @@ func (h *TestHelper) WaitForService(serviceName, state string, timeout time.Dura
 
 // CleanupQuadlet removes a deployed quadlet
 func (h *TestHelper) CleanupQuadlet(name string) {
-	// Stop and remove service
-	exec.Command("systemctl", "--user", "stop", name+".service").Run()
-	exec.Command("podman", "quadlet", "rm", "--user", name).Run()
+	// Stop and remove service (errors ignored in cleanup)
+	_ = exec.Command("systemctl", "--user", "stop", name+".service").Run()
+	_ = exec.Command("podman", "quadlet", "rm", "--user", name).Run()
 }
 
 // SkipIfNoPodman skips the test if Podman is not available

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -1,0 +1,36 @@
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+var legerBinary string
+
+func TestMain(m *testing.M) {
+	// Build leger binary for integration tests
+	tmpDir, err := os.MkdirTemp("", "leger-test-bin")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	legerBinary = filepath.Join(tmpDir, "leger")
+
+	// Build the leger binary
+	cmd := exec.Command("go", "build", "-o", legerBinary, "../../cmd/leger")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		panic("Failed to build leger binary: " + string(output))
+	}
+
+	// Add binary directory to PATH
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+	defer os.Setenv("PATH", oldPath)
+
+	// Run tests
+	code := m.Run()
+	os.Exit(code)
+}

--- a/tests/integration/staging_test.go
+++ b/tests/integration/staging_test.go
@@ -41,13 +41,13 @@ func TestStagingWorkflow(t *testing.T) {
 
 	// 4. Show diff
 	t.Log("Step 4: Showing diff")
-	output, err = h.RunCommand("diff", deploymentName)
+	output, _ = h.RunCommand("diff", deploymentName)
 	// Diff might fail if nothing staged
 	t.Logf("Diff result: %s", output)
 
 	// 5. Discard staged updates
 	t.Log("Step 5: Discarding staged updates")
-	output, err = h.RunCommand("discard", deploymentName)
+	output, _ = h.RunCommand("discard", deploymentName)
 	// This might also fail if nothing was staged
 	t.Logf("Discard result: %s", output)
 }
@@ -74,7 +74,7 @@ func TestApplyStaged(t *testing.T) {
 	// Note: This test would need actual staged updates to be meaningful
 	// For now, we just verify the apply command doesn't crash
 	t.Log("Testing apply command")
-	output, err = h.RunCommand("apply", deploymentName, "--force")
+	output, _ = h.RunCommand("apply", deploymentName, "--force")
 	// Expected to fail if nothing staged
 	t.Logf("Apply result: %s", output)
 }


### PR DESCRIPTION
Implements ISSUE-21.md requirements to achieve 100% passing linting checks.

## Changes
- Remove unused import in internal/daemon/client_test.go
- Create tests/integration/main_test.go to build leger binary before tests
- Fix 14 errcheck issues for unchecked error returns
- Fix 3 ineffassign issues for ineffectual assignments
- Update deprecated Tailscale imports to new packages
- All golangci-lint checks now pass
- All unit tests pass
- Integration tests now find leger binary

Fixes #37

Generated with [Claude Code](https://claude.com/claude-code)