### PR TITLE
feat(auth): implement never-expiring tokens for v1.0

### DIFF
--- a/cmd/leger/auth.go
+++ b/cmd/leger/auth.go
@@ -148,7 +148,7 @@ func authStatusCmd() *cobra.Command {
 			}
 
 			if !storedAuth.IsValid() {
-				fmt.Println("Status:", ui.Warning("TOKEN EXPIRED"))
+				fmt.Println("Status:", ui.Warning("INVALID TOKEN"))
 				fmt.Println()
 				fmt.Println("Re-authenticate with: leger auth login")
 				return nil
@@ -157,20 +157,11 @@ func authStatusCmd() *cobra.Command {
 			fmt.Println("Status:", ui.Success("AUTHENTICATED"))
 			fmt.Printf("  User:    %s\n", storedAuth.UserEmail)
 			fmt.Printf("  UUID:    %s\n", storedAuth.UserUUID)
-			fmt.Printf("  Expires: %s\n", storedAuth.ExpiresAt.Format(time.RFC3339))
 			fmt.Println()
 
-			// Show time remaining
-			remaining := time.Until(storedAuth.ExpiresAt)
-			if remaining > 0 {
-				days := int(remaining.Hours() / 24)
-				if days > 0 {
-					fmt.Printf("  Token valid for %d more days\n", days)
-				} else {
-					hours := int(remaining.Hours())
-					fmt.Printf("  Token valid for %d more hours\n", hours)
-				}
-			}
+			// v1.0: Tokens do not expire
+			fmt.Println("Note: Tokens remain valid until you run 'leger auth logout'")
+			fmt.Println("      (Token expiry will be enforced in v1.1 with auto-refresh)")
 
 			return nil
 		},

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,53 @@
+# Authentication
+
+## v1.0 Token Behavior
+
+**IMPORTANT:** Tokens do NOT expire in v1.0. They remain valid indefinitely until you manually log out.
+
+### Token Lifecycle (v1.0)
+
+- **Creation:** Generated on `leger auth login`
+- **Expiry:** NONE - tokens never expire client-side
+- **Invalidation:** Only via `leger auth logout` or server rejection
+- **Future:** v1.1+ will add automatic token refresh with expiry validation
+
+### Why No Expiry in v1.0?
+
+1. **Simplicity:** Faster to ship first release
+2. **UX:** Users don't get unexpected "token expired" errors
+3. **Development:** Easier to test and debug
+4. **Roadmap:** Auto-refresh requires server-side changes (v1.1+)
+
+### Security Considerations
+
+⚠️ **Warning:** Since tokens never expire:
+- Anyone with access to `~/.local/share/leger/auth.json` has permanent access
+- Server-side token revocation is not implemented in v1.0
+- Run `leger auth logout` on shared machines
+
+### Token Storage
+
+- **Location:** `~/.local/share/leger/auth.json`
+- **Permissions:** `0600` (owner read/write only)
+- **Format:** JSON with token, expiry (ignored), user info
+
+### Commands
+
+```bash
+# Authenticate (creates never-expiring token)
+leger auth login
+
+# Check authentication status
+leger auth status
+
+# Manually invalidate token
+leger auth logout
+```
+
+## Roadmap: v1.1+ Auto-Refresh
+
+Future versions will implement:
+- ✅ Automatic token refresh
+- ✅ Expiry validation with safety buffer
+- ✅ Refresh token support (requires API changes)
+- ✅ Server-side token revocation

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -87,7 +87,7 @@ func TestTokenStoreClear(t *testing.T) {
 }
 
 func TestStoredAuthIsValid(t *testing.T) {
-	// Valid token (expires in future)
+	// v1.0: Token with valid data (should always be valid regardless of expiry)
 	validAuth := &StoredAuth{
 		Token:     "test-token",
 		TokenType: "Bearer",
@@ -96,25 +96,37 @@ func TestStoredAuthIsValid(t *testing.T) {
 		UserEmail: "alice@example.ts.net",
 	}
 	if !validAuth.IsValid() {
-		t.Error("expected valid token to be valid")
+		t.Error("v1.0: token with valid data should be valid")
 	}
 
-	// Expired token
-	expiredAuth := &StoredAuth{
+	// v1.0: Token with past expiry date (should still be valid)
+	pastExpiryAuth := &StoredAuth{
 		Token:     "test-token",
 		TokenType: "Bearer",
-		ExpiresAt: time.Now().Add(-1 * time.Hour),
+		ExpiresAt: time.Now().Add(-1 * time.Hour), // "Expired" 1 hour ago
 		UserUUID:  "user-123",
 		UserEmail: "alice@example.ts.net",
 	}
-	if expiredAuth.IsValid() {
-		t.Error("expected expired token to be invalid")
+	if !pastExpiryAuth.IsValid() {
+		t.Error("v1.0: token with past ExpiresAt should still be valid (expiry not enforced)")
 	}
 
-	// Nil auth
+	// Empty token (should be INVALID)
+	emptyAuth := &StoredAuth{
+		Token:     "", // Empty token
+		TokenType: "Bearer",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		UserUUID:  "user-123",
+		UserEmail: "alice@example.ts.net",
+	}
+	if emptyAuth.IsValid() {
+		t.Error("v1.0: empty token should be invalid")
+	}
+
+	// Nil auth (should be INVALID)
 	var nilAuth *StoredAuth
 	if nilAuth.IsValid() {
-		t.Error("expected nil auth to be invalid")
+		t.Error("v1.0: nil auth should be invalid")
 	}
 }
 

--- a/internal/legerrun/client.go
+++ b/internal/legerrun/client.go
@@ -469,7 +469,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 
 	// Handle error responses
 	if resp.StatusCode >= 400 {
-		return c.handleErrorResponse(resp)
+		return c.handleHTTPError(resp)
 	}
 
 	// Decode response
@@ -480,6 +480,19 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 	}
 
 	return nil
+}
+
+// handleHTTPError provides specific handling for common HTTP errors
+func (c *Client) handleHTTPError(resp *http.Response) error {
+	// Special handling for 401 Unauthorized
+	// Note: Even though v1.0 doesn't validate expiry client-side,
+	// the server may still reject tokens
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("authentication failed: token rejected by server\n\nRe-authenticate with: leger auth login")
+	}
+
+	// For other errors, parse the error response
+	return c.handleErrorResponse(resp)
 }
 
 func (c *Client) handleErrorResponse(resp *http.Response) error {


### PR DESCRIPTION
Implements the REVISED approach from issue #39 for v1.0 authentication.

## Changes

- Remove token expiry validation (tokens valid until manual logout)
- Fix config directory path to `~/.local/share/leger`
- Add 401-specific error handling with clear user guidance
- Update auth status command to reflect v1.0 behavior
- Add comprehensive documentation for v1.0 token lifecycle

## Testing

All tests passing:
- `TestTokenStoreSaveLoad` ✅
- `TestTokenStoreClear` ✅
- `TestStoredAuthIsValid` ✅

## Documentation

Created `docs/AUTHENTICATION.md` explaining:
- v1.0 token behavior (never-expiring)
- Security considerations
- Roadmap for v1.1+ auto-refresh

Token expiry validation and auto-refresh will be added in v1.1+.

Closes #39

Generated with [Claude Code](https://claude.ai/code)