### PR TITLE
fix: resolve go formatting issues and podman quadlet command compatib…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,17 @@ jobs:
         go-version: ['1.24']
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-      
+
+      - name: Install Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
       

--- a/cmd/leger/auth.go
+++ b/cmd/leger/auth.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/auth"
 	"github.com/leger-labs/leger/internal/legerrun"
 	"github.com/leger-labs/leger/internal/tailscale"
 	"github.com/leger-labs/leger/internal/ui"
 	"github.com/leger-labs/leger/internal/version"
+	"github.com/spf13/cobra"
 )
 
 // authCmd returns the auth command group

--- a/cmd/leger/backup.go
+++ b/cmd/leger/backup.go
@@ -7,8 +7,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/backup"
+	"github.com/spf13/cobra"
 )
 
 // backupCmd returns the backup command group

--- a/cmd/leger/config.go
+++ b/cmd/leger/config.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/auth"
 	"github.com/leger-labs/leger/internal/git"
 	"github.com/leger-labs/leger/internal/legerrun"
 	"github.com/leger-labs/leger/pkg/types"
+	"github.com/spf13/cobra"
 )
 
 // configCmd returns the config command group

--- a/cmd/leger/deploy.go
+++ b/cmd/leger/deploy.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/auth"
 	"github.com/leger-labs/leger/internal/daemon"
 	"github.com/leger-labs/leger/internal/git"
@@ -21,6 +20,7 @@ import (
 	"github.com/leger-labs/leger/internal/staging"
 	"github.com/leger-labs/leger/internal/ui"
 	"github.com/leger-labs/leger/internal/validation"
+	"github.com/spf13/cobra"
 )
 
 // deployCmd returns the deploy command group

--- a/cmd/leger/main.go
+++ b/cmd/leger/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/version"
+	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/leger/secrets.go
+++ b/cmd/leger/secrets.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/auth"
 	"github.com/leger-labs/leger/internal/legerrun"
 	"github.com/leger-labs/leger/internal/ui"
+	"github.com/spf13/cobra"
 )
 
 // secretsCmd returns the secrets command group

--- a/cmd/leger/service.go
+++ b/cmd/leger/service.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/health"
 	"github.com/leger-labs/leger/internal/podman"
 	"github.com/leger-labs/leger/internal/quadlet"
+	"github.com/spf13/cobra"
 )
 
 // serviceCmd returns the service command group

--- a/cmd/leger/staged.go
+++ b/cmd/leger/staged.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/staging"
+	"github.com/spf13/cobra"
 )
 
 // stagedCmd returns the staged command group

--- a/cmd/leger/status.go
+++ b/cmd/leger/status.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/daemon"
 	"github.com/leger-labs/leger/internal/staging"
+	"github.com/spf13/cobra"
 )
 
 // statusCmd returns the status command

--- a/cmd/leger/validate.go
+++ b/cmd/leger/validate.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
 	"github.com/leger-labs/leger/internal/validation"
+	"github.com/spf13/cobra"
 )
 
 // validateCmd returns the validate command

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -106,7 +106,7 @@ func (h *TestHelper) WaitForService(serviceName, state string, timeout time.Dura
 func (h *TestHelper) CleanupQuadlet(name string) {
 	// Stop and remove service (errors ignored in cleanup)
 	_ = exec.Command("systemctl", "--user", "stop", name+".service").Run()
-	_ = exec.Command("podman", "quadlet", "rm", "--user", name).Run()
+	_ = exec.Command("podman", "quadlet", "rm", name).Run()
 }
 
 // SkipIfNoPodman skips the test if Podman is not available


### PR DESCRIPTION
…ility

This commit addresses two critical CI failures:

1. **Go Formatting**: Applied go fmt to all files in cmd/leger/
   - Resolved presubmit check failures

2. **Podman Quadlet Command Compatibility**: Fixed podman quadlet commands
   - Removed unsupported --user flag from podman quadlet install/list/rm/print
   - Updated Install() to specify destination path based on scope:
     * User scope: ~/.config/containers/systemd
     * System scope: /etc/containers/systemd
   - Updated error messages with correct command syntax
   - Added Podman installation step to CI workflow

Files changed:
- internal/podman/quadlet.go: Fixed all quadlet command invocations
- tests/integration/helpers.go: Removed --user from cleanup commands
- .github/workflows/ci.yml: Added Podman installation for integration tests
- cmd/leger/*.go: Applied go fmt formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)