### PR TITLE
feat(packaging): add complete RPM distribution infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,35 @@ jobs:
         run: |
           nfpm pkg --packager rpm -f nfpm.yaml
 
+      - name: Import GPG key
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          # Trust the imported key
+          KEY_ID=$(gpg --list-keys --with-colons packages@leger.run | awk -F: '/^pub:/ {print $5}')
+          echo "${KEY_ID}:6:" | gpg --import-ownertrust
+
+      - name: Sign RPM
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        run: |
+          # Configure rpm macros for signing
+          cat > ~/.rpmmacros <<EOF
+          %_signature gpg
+          %_gpg_name packages@leger.run
+          EOF
+
+          # Sign all RPMs
+          for rpm in *.rpm; do
+            if [ -f "$rpm" ]; then
+              echo "Signing $rpm..."
+              rpmsign --addsign "$rpm"
+              # Verify signature
+              rpm --checksig "$rpm"
+            fi
+          done
+
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4
         with:
@@ -163,3 +192,60 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish to R2 Repository
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Organize RPMs
+        run: |
+          mkdir -p rpms
+          find artifacts -type f -name "*.rpm" -exec cp {} rpms/ \;
+          ls -lh rpms/
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y createrepo-c awscli
+
+      - name: Export GPG public key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          gpg --armor --export packages@leger.run > leger-rpm-signing.public.asc
+
+      - name: Publish to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          PUBLIC_URL: https://pkgs.leger.run
+          RPMS_DIR: ./rpms
+        run: |
+          chmod +x scripts/publish-rpm.sh
+          ./scripts/publish-rpm.sh
+
+      - name: Summary
+        run: |
+          echo "## RPM Repository Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Repository URL: https://pkgs.leger.run/fedora" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Installation instructions:" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "sudo dnf config-manager --add-repo https://pkgs.leger.run/fedora/leger.repo" >> $GITHUB_STEP_SUMMARY
+          echo "sudo dnf install leger" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ dist/
 *.deb
 *.tar.gz
 
+# GPG keys (never commit private keys!)
+*.private.asc
+*.keyid
+leger-rpm-signing.*
+
 # State directories
 *.state/
 /tmp/

--- a/docs/rpm-distribution-README.md
+++ b/docs/rpm-distribution-README.md
@@ -1,0 +1,266 @@
+# RPM Distribution Infrastructure
+
+Complete infrastructure for distributing Leger as RPM packages via a custom repository hosted on Cloudflare R2.
+
+## Quick Links
+
+- **[Setup Checklist](./rpm-distribution-checklist.md)** - Step-by-step checklist
+- **[Detailed Setup Guide](./rpm-distribution-setup.md)** - Complete documentation
+- **Repository URL:** https://pkgs.leger.run/fedora
+
+## What's Included
+
+This infrastructure provides:
+
+1. **Automated RPM builds** for x86_64 and aarch64 architectures
+2. **GPG signing** of all packages for security
+3. **Automated publishing** to Cloudflare R2 on each release
+4. **Repository metadata** generation for DNF/YUM integration
+5. **One-command installation** for end users
+
+## How It Works
+
+```
+Developer pushes tag → GitHub Actions builds & signs RPMs →
+Publishes to R2 → Users install with `dnf install leger`
+```
+
+### For Developers
+
+**Creating a release:**
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+GitHub Actions automatically:
+- Builds RPMs for amd64 and arm64
+- Signs them with GPG
+- Creates a GitHub Release
+- Publishes to R2 repository
+
+**Local development:**
+```bash
+make rpm-all              # Build RPMs
+make sign GPG_KEY=email   # Sign RPMs
+make verify               # Verify signatures
+```
+
+### For End Users
+
+**Installation:**
+```bash
+sudo dnf config-manager --add-repo https://pkgs.leger.run/fedora/leger.repo
+sudo dnf install leger
+```
+
+**Updates:**
+```bash
+sudo dnf update leger
+```
+
+## Files Structure
+
+```
+leger/
+├── .github/workflows/
+│   └── release.yml              # Builds, signs, publishes RPMs
+├── scripts/
+│   ├── generate-gpg-key.sh      # Creates GPG key pair
+│   └── publish-rpm.sh           # Publishes to R2 + generates repodata
+├── packaging/
+│   └── leger.repo               # Repository configuration for users
+├── docs/
+│   ├── rpm-distribution-README.md      # This file
+│   ├── rpm-distribution-setup.md       # Detailed setup guide
+│   └── rpm-distribution-checklist.md   # Setup checklist
+├── release/rpm/
+│   ├── postinst.sh              # Post-installation script
+│   ├── prerm.sh                 # Pre-removal script
+│   └── postrm.sh                # Post-removal script
+├── systemd/
+│   ├── legerd.service           # User service
+│   ├── legerd@.service          # System service
+│   └── legerd.default           # Default environment
+├── nfpm.yaml                    # RPM package configuration
+└── Makefile                     # Build targets
+```
+
+## Infrastructure Components
+
+### GitHub Actions Workflow
+
+**File:** `.github/workflows/release.yml`
+
+**Jobs:**
+1. **build** - Builds and signs RPMs for both architectures
+2. **release** - Creates GitHub Release with RPMs
+3. **publish** - Publishes to R2 repository
+
+**Secrets required:**
+- `GPG_PRIVATE_KEY` - Private GPG key for signing
+- `R2_ACCESS_KEY_ID` - Cloudflare R2 access key
+- `R2_SECRET_ACCESS_KEY` - Cloudflare R2 secret key
+- `R2_ENDPOINT` - R2 endpoint URL
+- `R2_BUCKET_NAME` - R2 bucket name
+
+### GPG Signing
+
+**Script:** `scripts/generate-gpg-key.sh`
+
+Generates a GPG key pair for signing RPM packages:
+- Key type: RSA 4096
+- Email: packages@leger.run
+- Never expires
+- No passphrase (for CI/CD automation)
+
+**Security:** Private key stored only in GitHub Secrets, never committed to git.
+
+### R2 Repository
+
+**Script:** `scripts/publish-rpm.sh`
+
+Publishes RPMs to Cloudflare R2:
+1. Downloads existing repository
+2. Adds new RPMs
+3. Generates/updates repository metadata (repodata)
+4. Uploads GPG public key
+5. Uploads repository configuration
+6. Syncs to R2 bucket
+
+**Structure:**
+```
+pkgs.leger.run/
+└── fedora/
+    ├── x86_64/
+    │   └── [RPM files]
+    ├── aarch64/
+    │   └── [RPM files]
+    ├── repodata/
+    │   ├── repomd.xml
+    │   └── [metadata files]
+    ├── repo.gpg          # Public GPG key
+    └── leger.repo        # Repository configuration
+```
+
+## Setup Overview
+
+### Phase 1: Infrastructure Files (✅ Complete)
+
+All necessary files have been created:
+- Scripts for GPG key generation and publishing
+- GitHub Actions workflow updates
+- Repository configuration template
+- Documentation
+
+### Phase 2: Manual Configuration (To Do)
+
+You need to:
+1. **Generate GPG key** - Run `./scripts/generate-gpg-key.sh`
+2. **Create R2 bucket** - Set up on Cloudflare dashboard
+3. **Configure custom domain** - Point `pkgs.leger.run` to R2
+4. **Add GitHub secrets** - Configure CI/CD credentials
+
+**See the [Setup Checklist](./rpm-distribution-checklist.md) for step-by-step instructions.**
+
+## Cost Estimate
+
+Cloudflare R2 is extremely cost-effective:
+
+**For Leger (estimated):**
+- Storage: ~0.5 GB → $0.0075/month
+- Operations: ~120K reads/month → $0.04/month
+- Egress: FREE (unlimited)
+
+**Total: ~$0.60/year**
+
+vs AWS S3:
+- Storage: ~$0.12/month
+- Operations: ~$0.04/month
+- Egress: ~$10-100/month (10GB-100GB at $0.09/GB)
+
+**R2 saves ~$120-1200/year** on egress alone!
+
+## Maintenance
+
+### Regular Releases
+
+Just push a tag - automation handles the rest:
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+### Quarterly Tasks
+
+- Rotate R2 API tokens (recommended)
+- Review usage and costs in Cloudflare dashboard
+
+### Annual Tasks
+
+- Consider rotating GPG key
+- Update documentation
+- Audit access controls
+
+## Testing
+
+### Before First Production Release
+
+1. Generate GPG key locally
+2. Test local build and signing
+3. Create test tag (`v0.0.1-test`)
+4. Verify GitHub Actions workflow
+5. Configure R2 and GitHub secrets
+6. Create production tag (`v0.1.0`)
+7. Verify repository is accessible
+8. Test installation on Fedora/RHEL
+
+### For Each Release
+
+1. Monitor GitHub Actions workflow
+2. Verify GitHub Release created
+3. Check R2 repository updated
+4. Test installation update
+
+## Troubleshooting
+
+### Common Issues
+
+**"GPG signature verification failed"**
+- Ensure `repo.gpg` is accessible at repository URL
+- Import key manually: `sudo rpm --import https://pkgs.leger.run/fedora/repo.gpg`
+
+**"Failed to synchronize cache for repo 'leger-stable'"**
+- Check repository URL is accessible
+- Verify custom domain DNS is configured
+- Clear DNF cache: `sudo dnf clean all && sudo dnf makecache`
+
+**GitHub Actions failing at "Sign RPM"**
+- Verify `GPG_PRIVATE_KEY` secret is set correctly
+- Check key email matches `packages@leger.run`
+
+**GitHub Actions failing at "Publish to R2"**
+- Verify all R2 secrets are set
+- Check R2 bucket permissions
+- Ensure R2 API token has write access
+
+**See [Detailed Setup Guide](./rpm-distribution-setup.md) for more troubleshooting.**
+
+## References
+
+- [Cloudflare R2 Documentation](https://developers.cloudflare.com/r2/)
+- [RPM Packaging Guide](https://rpm-packaging-guide.github.io/)
+- [nfpm Documentation](https://nfpm.goreleaser.com/)
+- [createrepo_c](https://github.com/rpm-software-management/createrepo_c)
+- [DNF Configuration](https://dnf.readthedocs.io/)
+
+## Support
+
+- **Issues:** https://github.com/leger-labs/leger/issues
+- **Email:** packages@leger.run
+- **Docs:** https://leger.run/docs/
+
+---
+
+**Status:** Infrastructure files complete, ready for manual configuration steps.

--- a/docs/rpm-distribution-checklist.md
+++ b/docs/rpm-distribution-checklist.md
@@ -1,0 +1,358 @@
+# RPM Distribution Setup Checklist
+
+Quick checklist for setting up the RPM distribution infrastructure. See [rpm-distribution-setup.md](./rpm-distribution-setup.md) for detailed instructions.
+
+## Phase 1: Infrastructure Setup (Complete First)
+
+### ✅ Repository Files Created
+
+- [x] `scripts/generate-gpg-key.sh` - GPG key generation script
+- [x] `scripts/publish-rpm.sh` - R2 publishing script
+- [x] `packaging/leger.repo` - Repository configuration template
+- [x] `.github/workflows/release.yml` - Updated with signing & publishing
+- [x] `.gitignore` - Updated to exclude GPG private keys
+
+### ✅ Existing Infrastructure (Already in place)
+
+- [x] `nfpm.yaml` - RPM package configuration
+- [x] `Makefile` - Build and sign targets
+- [x] `systemd/` - Service files
+- [x] `release/rpm/` - Install/uninstall scripts
+- [x] `config/leger.yaml` - Default configuration
+
+## Phase 2: GPG Key Generation
+
+### [ ] Generate GPG Key Pair
+
+```bash
+cd /home/user/leger
+./scripts/generate-gpg-key.sh
+```
+
+**Creates:**
+- `leger-rpm-signing.private.asc` (DO NOT COMMIT!)
+- `leger-rpm-signing.public.asc`
+- `leger-rpm-signing.keyid`
+
+**Verify:**
+```bash
+gpg --list-keys packages@leger.run
+```
+
+### [ ] Secure the Private Key
+
+- [ ] Backup private key to secure location (password manager, encrypted drive)
+- [ ] Confirm `.gitignore` excludes `*.private.asc`
+- [ ] Never commit private key to git
+
+## Phase 3: Cloudflare R2 Setup (Manual)
+
+### [ ] Create R2 Bucket
+
+1. Log in to Cloudflare Dashboard
+2. Navigate to R2 Object Storage
+3. Create bucket named `leger-packages`
+4. Choose location closest to users
+
+**Settings:**
+- Name: `leger-packages`
+- Location: Auto
+- Versioning: Disabled
+
+### [ ] Create R2 API Token
+
+1. Go to "Manage R2 API Tokens"
+2. Create token: `github-actions-rpm-publisher`
+3. Permissions: Object Read & Write on `leger-packages`
+4. **Save these values:**
+
+```
+Access Key ID: _______________________________
+Secret Access Key: _______________________________
+Endpoint URL: https://________________.r2.cloudflarestorage.com
+```
+
+### [ ] Configure Custom Domain
+
+1. In bucket settings → Custom Domains
+2. Add domain: `pkgs.leger.run`
+3. Add DNS record as instructed by Cloudflare:
+
+```
+Type: CNAME
+Name: pkgs
+Target: [provided by Cloudflare]
+```
+
+4. Wait for DNS propagation (usually < 5 minutes)
+5. Verify: `curl -I https://pkgs.leger.run/`
+
+### [ ] Optional: Configure CORS
+
+For browser access to repository metadata:
+
+```json
+[
+  {
+    "AllowedOrigins": ["*"],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+## Phase 4: GitHub Secrets Configuration (Manual)
+
+### [ ] Add Secrets to GitHub Repository
+
+Go to: `Settings` → `Secrets and variables` → `Actions` → `New repository secret`
+
+#### Required Secrets:
+
+| Secret Name | Source | Example |
+|-------------|--------|---------|
+| `GPG_PRIVATE_KEY` | Contents of `leger-rpm-signing.private.asc` | -----BEGIN PGP PRIVATE KEY BLOCK----- ... |
+| `R2_ACCESS_KEY_ID` | From R2 API Token creation | abc123... |
+| `R2_SECRET_ACCESS_KEY` | From R2 API Token creation | xyz789... |
+| `R2_ENDPOINT` | From R2 API Token creation | https://abc.r2.cloudflarestorage.com |
+| `R2_BUCKET_NAME` | Bucket name from Phase 3 | leger-packages |
+
+**To add GPG_PRIVATE_KEY:**
+
+```bash
+cat leger-rpm-signing.private.asc
+# Copy entire output including BEGIN/END markers
+```
+
+#### Verify Secrets Are Set:
+
+- [ ] `GPG_PRIVATE_KEY` - Contains full private key with headers
+- [ ] `R2_ACCESS_KEY_ID` - R2 access key ID
+- [ ] `R2_SECRET_ACCESS_KEY` - R2 secret access key
+- [ ] `R2_ENDPOINT` - R2 endpoint URL with https://
+- [ ] `R2_BUCKET_NAME` - Bucket name
+
+## Phase 5: Testing
+
+### [ ] Local Build Test
+
+```bash
+# Build RPMs for all architectures
+make rpm-all
+
+# Verify build
+ls -lh *.rpm
+```
+
+### [ ] Local Signing Test
+
+```bash
+# Import GPG key if not already in keyring
+gpg --import leger-rpm-signing.private.asc
+
+# Sign RPMs
+make sign GPG_KEY=packages@leger.run
+
+# Verify signatures
+make verify
+```
+
+Expected output:
+```
+leger-*.rpm: digests signatures OK
+```
+
+### [ ] Local Publishing Test (Optional)
+
+```bash
+# Set R2 credentials
+export R2_ACCESS_KEY_ID="your-key-id"
+export R2_SECRET_ACCESS_KEY="your-secret-key"
+export R2_ENDPOINT="your-endpoint"
+export R2_BUCKET_NAME="leger-packages"
+
+# Test publish script
+./scripts/publish-rpm.sh
+```
+
+### [ ] GitHub Actions Test Release
+
+```bash
+# Create test tag (won't publish to R2, just builds)
+git tag v0.0.1-test
+git push origin v0.0.1-test
+```
+
+**Verify:**
+1. Go to GitHub Actions tab
+2. Watch "Release" workflow
+3. Check all jobs succeed:
+   - [ ] Build (amd64)
+   - [ ] Build (arm64)
+   - [ ] Create GitHub Release
+4. Check RPMs are signed:
+   - Download RPM from release
+   - Run: `rpm --checksig leger-*.rpm`
+
+### [ ] Production Release Test
+
+```bash
+# Create production release
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+**Verify:**
+1. GitHub Actions completes all jobs
+2. GitHub Release is created with RPMs
+3. R2 repository is updated:
+
+```bash
+# Check repository metadata
+curl -I https://pkgs.leger.run/fedora/repodata/repomd.xml
+# Should return 200 OK
+
+# Check GPG key
+curl https://pkgs.leger.run/fedora/repo.gpg | gpg --import
+# Should import successfully
+
+# Check repository config
+curl https://pkgs.leger.run/fedora/leger.repo
+# Should show repository configuration
+```
+
+## Phase 6: End-User Installation Test
+
+### [ ] Test on Fedora/RHEL System
+
+```bash
+# Add repository
+sudo dnf config-manager --add-repo https://pkgs.leger.run/fedora/leger.repo
+
+# Refresh metadata
+sudo dnf makecache
+
+# Search for package
+sudo dnf search leger
+
+# Install
+sudo dnf install leger
+
+# Verify installation
+leger --version
+systemctl --user status legerd.service
+```
+
+### [ ] Verify GPG Signature Verification
+
+```bash
+# Should show GPG signature check passed
+sudo dnf install -y leger
+```
+
+Look for: `GPG key signature verification passed`
+
+## Phase 7: Documentation Updates
+
+### [ ] Update Installation Documentation
+
+Add to README.md or installation guide:
+
+```markdown
+## Installation
+
+### Fedora / RHEL / Rocky Linux
+
+```bash
+sudo dnf config-manager --add-repo https://pkgs.leger.run/fedora/leger.repo
+sudo dnf install leger
+```
+```
+
+### [ ] Update Website
+
+- [ ] Add installation instructions to https://leger.run
+- [ ] Add supported distributions
+- [ ] Link to documentation
+
+### [ ] Announce Release
+
+- [ ] GitHub Discussions/Announcements
+- [ ] Social media
+- [ ] Mailing list (if applicable)
+
+## Ongoing Maintenance
+
+### For Each New Release:
+
+1. [ ] Commit changes to main branch
+2. [ ] Create and push tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+3. [ ] Monitor GitHub Actions workflow
+4. [ ] Verify GitHub Release is created
+5. [ ] Verify R2 repository is updated
+6. [ ] Test installation: `sudo dnf install --refresh leger`
+
+### Quarterly:
+
+- [ ] Rotate R2 API tokens
+- [ ] Review R2 usage and costs
+- [ ] Check for security updates to dependencies
+
+### Annually:
+
+- [ ] Consider rotating GPG key
+- [ ] Review and update documentation
+- [ ] Audit access controls
+
+## Troubleshooting
+
+### Workflow fails at "Sign RPM"
+
+- Check `GPG_PRIVATE_KEY` secret is set correctly
+- Verify key email matches `packages@leger.run`
+- Review workflow logs for specific error
+
+### Workflow fails at "Publish to R2"
+
+- Verify all R2 secrets are set
+- Check R2 bucket name and permissions
+- Ensure R2 API token has write access
+
+### Users can't install package
+
+```bash
+# On user's system, check:
+curl -I https://pkgs.leger.run/fedora/repodata/repomd.xml
+# Should return 200
+
+# Import GPG key manually
+sudo rpm --import https://pkgs.leger.run/fedora/repo.gpg
+
+# Clear DNF cache
+sudo dnf clean all
+sudo dnf makecache
+```
+
+### Signature verification fails
+
+- Ensure `repo.gpg` is accessible at repository URL
+- Verify GPG key in `repo.gpg` matches signing key
+- Check repository configuration has correct `gpgkey` URL
+
+## Resources
+
+- [Detailed Setup Guide](./rpm-distribution-setup.md)
+- [Cloudflare R2 Dashboard](https://dash.cloudflare.com)
+- [GitHub Repository Settings](https://github.com/leger-labs/leger/settings)
+- [GitHub Actions](https://github.com/leger-labs/leger/actions)
+
+## Status Tracking
+
+**Setup Started:** _______________________
+**GPG Key Generated:** _______________________
+**R2 Bucket Created:** _______________________
+**GitHub Secrets Added:** _______________________
+**First Test Release:** _______________________
+**First Production Release:** _______________________
+**Setup Complete:** _______________________

--- a/docs/rpm-distribution-setup.md
+++ b/docs/rpm-distribution-setup.md
@@ -1,0 +1,380 @@
+# RPM Distribution Infrastructure Setup
+
+This guide walks through setting up the complete RPM distribution infrastructure for Leger, including GPG signing, GitHub Actions automation, and Cloudflare R2 repository hosting.
+
+## Overview
+
+The distribution infrastructure consists of:
+
+1. **GPG key pair** for signing RPM packages
+2. **GitHub Actions workflow** for automated builds, signing, and publishing
+3. **Cloudflare R2 bucket** for hosting the RPM repository
+4. **Repository metadata** (repodata) for DNF/YUM integration
+5. **Public repository configuration** for easy user installation
+
+## Architecture
+
+```
+┌─────────────────┐
+│  Git Tag Push   │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────────────────────┐
+│   GitHub Actions Workflow       │
+│  ┌──────────────────────────┐  │
+│  │ 1. Build (amd64 + arm64) │  │
+│  └──────────┬───────────────┘  │
+│             │                   │
+│             ▼                   │
+│  ┌──────────────────────────┐  │
+│  │ 2. Sign RPMs with GPG    │  │
+│  └──────────┬───────────────┘  │
+│             │                   │
+│             ▼                   │
+│  ┌──────────────────────────┐  │
+│  │ 3. Create GitHub Release │  │
+│  └──────────┬───────────────┘  │
+│             │                   │
+│             ▼                   │
+│  ┌──────────────────────────┐  │
+│  │ 4. Publish to R2         │  │
+│  │    - Upload RPMs         │  │
+│  │    - Generate repodata   │  │
+│  │    - Upload GPG key      │  │
+│  └──────────┬───────────────┘  │
+└─────────────┼───────────────────┘
+              │
+              ▼
+     ┌────────────────────┐
+     │  Cloudflare R2     │
+     │  pkgs.leger.run    │
+     │  ├── fedora/       │
+     │      ├── x86_64/   │
+     │      ├── aarch64/  │
+     │      ├── repodata/ │
+     │      ├── repo.gpg  │
+     │      └── leger.repo│
+     └────────────────────┘
+              │
+              ▼
+     ┌────────────────────┐
+     │  End Users         │
+     │  dnf install leger │
+     └────────────────────┘
+```
+
+## Step 1: Generate GPG Key Pair
+
+Generate a GPG key pair for signing RPM packages:
+
+```bash
+./scripts/generate-gpg-key.sh
+```
+
+This will create:
+- `leger-rpm-signing.private.asc` - Private key (keep secret!)
+- `leger-rpm-signing.public.asc` - Public key (distribute to users)
+- `leger-rpm-signing.keyid` - Key ID for reference
+
+**Important:**
+- Never commit the private key to git
+- Add `*.private.asc` to `.gitignore`
+- Store the private key securely
+
+## Step 2: Set Up Cloudflare R2 Bucket
+
+### 2.1 Create R2 Bucket
+
+1. Log in to Cloudflare Dashboard
+2. Navigate to R2 Object Storage
+3. Click "Create bucket"
+4. Name: `leger-packages` (or your preferred name)
+5. Location: Auto (or choose closest to your users)
+6. Click "Create bucket"
+
+### 2.2 Create R2 API Token
+
+1. In R2, go to "Manage R2 API Tokens"
+2. Click "Create API token"
+3. Name: `github-actions-rpm-publisher`
+4. Permissions:
+   - Object Read & Write
+   - Bucket: `leger-packages`
+5. Click "Create API Token"
+6. **Save the credentials:**
+   - Access Key ID
+   - Secret Access Key
+   - Endpoint URL (format: `https://<account-id>.r2.cloudflarestorage.com`)
+
+### 2.3 Configure Custom Domain
+
+1. In your R2 bucket settings, go to "Settings" → "Custom Domains"
+2. Click "Connect Domain"
+3. Enter: `pkgs.leger.run`
+4. Follow the DNS setup instructions
+5. Wait for DNS propagation (usually < 5 minutes)
+
+### 2.4 Configure Bucket CORS (Optional)
+
+If you want to allow browsers to fetch repository metadata:
+
+```json
+[
+  {
+    "AllowedOrigins": ["*"],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+## Step 3: Configure GitHub Secrets
+
+Add the following secrets to your GitHub repository:
+
+1. Go to repository Settings → Secrets and variables → Actions
+2. Click "New repository secret" for each:
+
+| Secret Name | Value | Description |
+|-------------|-------|-------------|
+| `GPG_PRIVATE_KEY` | Contents of `leger-rpm-signing.private.asc` | Private GPG key for signing RPMs |
+| `R2_ACCESS_KEY_ID` | From Step 2.2 | R2 API token access key |
+| `R2_SECRET_ACCESS_KEY` | From Step 2.2 | R2 API token secret |
+| `R2_ENDPOINT` | From Step 2.2 | R2 endpoint URL |
+| `R2_BUCKET_NAME` | `leger-packages` | R2 bucket name |
+
+**To add GPG_PRIVATE_KEY:**
+
+```bash
+# Display the private key
+cat leger-rpm-signing.private.asc
+
+# Copy the entire output including:
+# -----BEGIN PGP PRIVATE KEY BLOCK-----
+# ...
+# -----END PGP PRIVATE KEY BLOCK-----
+```
+
+Paste the entire key (including headers) into the GitHub secret value.
+
+## Step 4: Test the Workflow
+
+### 4.1 Local Testing
+
+Test building and signing locally:
+
+```bash
+# Build RPMs
+make rpm-all
+
+# Sign RPMs (requires GPG key in keyring)
+make sign GPG_KEY=packages@leger.run
+
+# Verify signatures
+make verify
+
+# Test publishing (requires R2 credentials)
+export R2_ACCESS_KEY_ID="your-key"
+export R2_SECRET_ACCESS_KEY="your-secret"
+export R2_ENDPOINT="https://your-account.r2.cloudflarestorage.com"
+export R2_BUCKET_NAME="leger-packages"
+./scripts/publish-rpm.sh
+```
+
+### 4.2 Test GitHub Actions
+
+Create a test tag:
+
+```bash
+git tag v0.0.1-test
+git push origin v0.0.1-test
+```
+
+This will trigger the workflow but won't publish to R2 (pre-release tags are skipped).
+
+Monitor the workflow:
+1. Go to GitHub Actions tab
+2. Watch the "Release" workflow
+3. Check all jobs complete successfully
+
+### 4.3 First Production Release
+
+When ready for production:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+This will:
+1. Build RPMs for amd64 and arm64
+2. Sign them with GPG
+3. Create a GitHub Release
+4. Publish to R2 repository
+
+## Step 5: Verify Repository
+
+After the first release, verify the repository is working:
+
+```bash
+# Check repository is accessible
+curl -I https://pkgs.leger.run/fedora/repodata/repomd.xml
+
+# Check GPG key is available
+curl https://pkgs.leger.run/fedora/repo.gpg
+
+# Check repository configuration
+curl https://pkgs.leger.run/fedora/leger.repo
+
+# Test installation on a Fedora/RHEL system
+sudo dnf config-manager --add-repo https://pkgs.leger.run/fedora/leger.repo
+sudo dnf makecache
+sudo dnf search leger
+sudo dnf install leger
+```
+
+## Step 6: User Installation Instructions
+
+Update your documentation with these installation instructions:
+
+### Quick Install
+
+```bash
+# Add repository
+sudo dnf config-manager --add-repo https://pkgs.leger.run/fedora/leger.repo
+
+# Install
+sudo dnf install leger
+```
+
+### Manual Repository Setup
+
+Create `/etc/yum.repos.d/leger.repo`:
+
+```ini
+[leger-stable]
+name=Leger Stable Repository
+baseurl=https://pkgs.leger.run/fedora/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.leger.run/fedora/repo.gpg
+repo_gpgcheck=1
+metadata_expire=1h
+```
+
+Then install:
+
+```bash
+sudo dnf install leger
+```
+
+## Maintenance
+
+### Updating the Repository
+
+The repository updates automatically on each release. When you push a new tag:
+
+1. GitHub Actions builds and signs new RPMs
+2. The publish job downloads existing repository
+3. Adds new RPMs
+4. Updates repository metadata
+5. Uploads everything to R2
+
+Users will see updates within their configured metadata expiry time (default: 1 hour).
+
+### Rotating GPG Keys
+
+If you need to rotate GPG keys:
+
+1. Generate new key: `./scripts/generate-gpg-key.sh`
+2. Update `GPG_PRIVATE_KEY` GitHub secret
+3. Keep old public key available for old packages
+4. Next release will be signed with new key
+
+### Troubleshooting
+
+**RPMs not signed:**
+- Check `GPG_PRIVATE_KEY` secret is set correctly
+- Verify key email is `packages@leger.run`
+- Check workflow logs for signing step
+
+**Repository not updating:**
+- Check R2 credentials in GitHub secrets
+- Verify R2 bucket permissions
+- Check publish job logs
+
+**Users can't verify signatures:**
+- Ensure `repo.gpg` is accessible
+- Check GPG key was exported correctly
+- Verify repository configuration has correct `gpgkey` URL
+
+**DNF cache issues:**
+```bash
+# Clear cache
+sudo dnf clean all
+sudo dnf makecache
+
+# Force refresh
+sudo dnf --refresh search leger
+```
+
+## Cost Considerations
+
+### Cloudflare R2 Pricing (as of 2024)
+
+- **Storage:** $0.015/GB/month
+- **Class A operations** (writes): $4.50/million
+- **Class B operations** (reads): $0.36/million
+- **Egress:** FREE (this is the big win vs S3!)
+
+### Estimated Costs for Leger
+
+Assuming:
+- 2 RPMs per release (amd64 + arm64) × ~20 MB each = 40 MB
+- 12 releases per year
+- 10,000 downloads per release
+
+**Monthly costs:**
+- Storage: ~0.5 GB × $0.015 = $0.0075
+- Writes: ~50 operations × $4.50/1M = $0.0002
+- Reads: ~120,000 operations × $0.36/1M = $0.04
+
+**Total: ~$0.05/month or $0.60/year**
+
+Much cheaper than GitHub LFS or other alternatives!
+
+## Security Best Practices
+
+1. **GPG Key Management:**
+   - Use a strong passphrase (or no passphrase for CI/CD)
+   - Store private key in GitHub Secrets only
+   - Rotate keys annually
+   - Keep offline backup of private key
+
+2. **R2 API Tokens:**
+   - Use minimal permissions (read/write to specific bucket only)
+   - Rotate tokens every 90 days
+   - Monitor token usage in Cloudflare dashboard
+
+3. **Repository Security:**
+   - Always sign RPMs (`gpgcheck=1`)
+   - Enable repo metadata signature checking (`repo_gpgcheck=1`)
+   - Use HTTPS for all repository URLs
+
+## References
+
+- [nfpm Documentation](https://nfpm.goreleaser.com/)
+- [Cloudflare R2 Documentation](https://developers.cloudflare.com/r2/)
+- [RPM Packaging Guide](https://rpm-packaging-guide.github.io/)
+- [createrepo_c Documentation](https://github.com/rpm-software-management/createrepo_c)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+
+## Support
+
+For issues with the distribution infrastructure:
+- GitHub Issues: https://github.com/leger-labs/leger/issues
+- Email: packages@leger.run
+- Documentation: https://leger.run/docs/

--- a/packaging/leger.repo
+++ b/packaging/leger.repo
@@ -1,0 +1,8 @@
+[leger-stable]
+name=Leger Stable Repository
+baseurl=https://pkgs.leger.run/fedora/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.leger.run/fedora/repo.gpg
+repo_gpgcheck=1
+metadata_expire=1h

--- a/scripts/generate-gpg-key.sh
+++ b/scripts/generate-gpg-key.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Generate GPG key for signing RPM packages
+# This script creates a GPG key pair for the Leger package repository
+
+set -euo pipefail
+
+# Configuration
+KEY_TYPE="RSA"
+KEY_LENGTH="4096"
+KEY_USAGE="sign"
+KEY_NAME="Leger Package Signing"
+KEY_EMAIL="packages@leger.run"
+KEY_COMMENT="RPM package signing key"
+KEY_EXPIRE="0"  # Never expire
+
+# Output files
+PRIVATE_KEY_FILE="leger-rpm-signing.private.asc"
+PUBLIC_KEY_FILE="leger-rpm-signing.public.asc"
+KEY_ID_FILE="leger-rpm-signing.keyid"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if GPG is installed
+if ! command -v gpg &> /dev/null; then
+    echo -e "${RED}Error: gpg is not installed${NC}"
+    echo "Install it with: sudo dnf install gnupg2"
+    exit 1
+fi
+
+# Check if rpm-sign is installed (needed for signing)
+if ! command -v rpmsign &> /dev/null; then
+    echo -e "${YELLOW}Warning: rpm-sign is not installed${NC}"
+    echo "You'll need it later for signing. Install with: sudo dnf install rpm-sign"
+fi
+
+echo -e "${GREEN}Generating GPG key for RPM signing...${NC}"
+echo ""
+echo "Key details:"
+echo "  Name:    $KEY_NAME"
+echo "  Email:   $KEY_EMAIL"
+echo "  Comment: $KEY_COMMENT"
+echo "  Type:    $KEY_TYPE $KEY_LENGTH"
+echo "  Expires: Never"
+echo ""
+
+# Generate passphrase-less key for CI/CD
+# In production, you might want a passphrase for security
+cat > /tmp/gpg-key-config <<EOF
+%echo Generating RPM signing key
+Key-Type: $KEY_TYPE
+Key-Length: $KEY_LENGTH
+Key-Usage: $KEY_USAGE
+Name-Real: $KEY_NAME
+Name-Comment: $KEY_COMMENT
+Name-Email: $KEY_EMAIL
+Expire-Date: $KEY_EXPIRE
+%no-protection
+%commit
+%echo Done
+EOF
+
+echo -e "${YELLOW}Generating key (this may take a minute)...${NC}"
+gpg --batch --generate-key /tmp/gpg-key-config
+
+# Get the key ID
+KEY_ID=$(gpg --list-keys --with-colons "$KEY_EMAIL" | awk -F: '/^pub:/ {print $5}')
+
+if [ -z "$KEY_ID" ]; then
+    echo -e "${RED}Error: Failed to generate key${NC}"
+    rm -f /tmp/gpg-key-config
+    exit 1
+fi
+
+echo -e "${GREEN}Key generated successfully!${NC}"
+echo "Key ID: $KEY_ID"
+echo ""
+
+# Export private key (for CI/CD secrets)
+echo "Exporting private key..."
+gpg --armor --export-secret-keys "$KEY_EMAIL" > "$PRIVATE_KEY_FILE"
+
+# Export public key (for repository)
+echo "Exporting public key..."
+gpg --armor --export "$KEY_EMAIL" > "$PUBLIC_KEY_FILE"
+
+# Save key ID
+echo "$KEY_ID" > "$KEY_ID_FILE"
+
+# Cleanup
+rm -f /tmp/gpg-key-config
+
+echo ""
+echo -e "${GREEN}GPG key pair created successfully!${NC}"
+echo ""
+echo "Files created:"
+echo "  Private key: $PRIVATE_KEY_FILE (keep this SECRET!)"
+echo "  Public key:  $PUBLIC_KEY_FILE (distribute this)"
+echo "  Key ID:      $KEY_ID_FILE"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo ""
+echo "1. Add private key to GitHub Secrets:"
+echo "   - Name: GPG_PRIVATE_KEY"
+echo "   - Value: Contents of $PRIVATE_KEY_FILE"
+echo ""
+echo "2. Add passphrase to GitHub Secrets (if you used one):"
+echo "   - Name: GPG_PASSPHRASE"
+echo "   - Value: Your passphrase (empty for this key)"
+echo ""
+echo "3. Upload public key to your R2 bucket:"
+echo "   - File: $PUBLIC_KEY_FILE"
+echo "   - Upload to: https://pkgs.leger.run/fedora/repo.gpg"
+echo ""
+echo "4. To sign RPMs locally:"
+echo "   make sign GPG_KEY=$KEY_EMAIL"
+echo ""
+echo -e "${RED}IMPORTANT: Keep $PRIVATE_KEY_FILE secure and never commit it to git!${NC}"
+echo ""

--- a/scripts/publish-rpm.sh
+++ b/scripts/publish-rpm.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# Publish RPM packages to Cloudflare R2 and generate repository metadata
+# This script handles the complete publishing pipeline:
+# 1. Upload RPM files to R2
+# 2. Generate/update RPM repository metadata (repodata)
+# 3. Upload public GPG key
+# 4. Upload repository configuration file
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+BUCKET_NAME="${R2_BUCKET_NAME:-leger-packages}"
+BUCKET_ENDPOINT="${R2_ENDPOINT:-https://your-account-id.r2.cloudflarestorage.com}"
+PUBLIC_URL="${PUBLIC_URL:-https://pkgs.leger.run}"
+ARCH="${ARCH:-x86_64}"  # Can be x86_64 or aarch64
+
+# Directories
+RPMS_DIR="${RPMS_DIR:-./rpms}"
+TEMP_DIR=$(mktemp -d)
+
+# Cleanup on exit
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+# Check required environment variables
+check_requirements() {
+    local missing=0
+
+    if [ -z "${R2_ACCESS_KEY_ID:-}" ]; then
+        echo -e "${RED}Error: R2_ACCESS_KEY_ID not set${NC}"
+        missing=1
+    fi
+
+    if [ -z "${R2_SECRET_ACCESS_KEY:-}" ]; then
+        echo -e "${RED}Error: R2_SECRET_ACCESS_KEY not set${NC}"
+        missing=1
+    fi
+
+    if ! command -v aws &> /dev/null; then
+        echo -e "${RED}Error: AWS CLI not installed${NC}"
+        echo "Install it with: pip install awscli"
+        missing=1
+    fi
+
+    if ! command -v createrepo_c &> /dev/null; then
+        echo -e "${RED}Error: createrepo_c not installed${NC}"
+        echo "Install it with: sudo dnf install createrepo_c"
+        missing=1
+    fi
+
+    if [ $missing -eq 1 ]; then
+        exit 1
+    fi
+}
+
+# Configure AWS CLI for R2
+configure_s3() {
+    export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+    export AWS_DEFAULT_REGION="auto"
+}
+
+# Upload file to R2
+s3_upload() {
+    local src="$1"
+    local dst="$2"
+
+    echo -e "${BLUE}Uploading $src -> $dst${NC}"
+    aws s3 cp "$src" "s3://${BUCKET_NAME}/${dst}" \
+        --endpoint-url "$BUCKET_ENDPOINT" \
+        --no-progress
+}
+
+# Download directory from R2
+s3_download_dir() {
+    local remote="$1"
+    local local="$2"
+
+    echo -e "${BLUE}Downloading $remote -> $local${NC}"
+    aws s3 sync "s3://${BUCKET_NAME}/${remote}" "$local" \
+        --endpoint-url "$BUCKET_ENDPOINT" \
+        --no-progress 2>/dev/null || true
+}
+
+# Upload directory to R2
+s3_upload_dir() {
+    local local="$1"
+    local remote="$2"
+
+    echo -e "${BLUE}Uploading $local -> $remote${NC}"
+    aws s3 sync "$local" "s3://${BUCKET_NAME}/${remote}" \
+        --endpoint-url "$BUCKET_ENDPOINT" \
+        --no-progress
+}
+
+# Main publishing flow
+main() {
+    echo -e "${GREEN}=== Publishing RPMs to R2 ===${NC}"
+    echo ""
+
+    # Check requirements
+    check_requirements
+    configure_s3
+
+    # Create working directory
+    local REPO_DIR="$TEMP_DIR/fedora"
+    mkdir -p "$REPO_DIR"
+
+    # Download existing repository metadata (if any)
+    echo -e "${YELLOW}Downloading existing repository metadata...${NC}"
+    s3_download_dir "fedora" "$REPO_DIR"
+
+    # Copy new RPMs to repository
+    echo -e "${YELLOW}Adding new RPMs...${NC}"
+    if [ -d "$RPMS_DIR" ]; then
+        for rpm in "$RPMS_DIR"/*.rpm; do
+            if [ -f "$rpm" ]; then
+                cp -v "$rpm" "$REPO_DIR/"
+            fi
+        done
+    else
+        echo -e "${RED}Error: RPMs directory not found: $RPMS_DIR${NC}"
+        exit 1
+    fi
+
+    # Generate repository metadata
+    echo -e "${YELLOW}Generating repository metadata...${NC}"
+    if [ -f "$REPO_DIR/repodata/repomd.xml" ]; then
+        # Update existing repo
+        createrepo_c --update "$REPO_DIR"
+    else
+        # Create new repo
+        createrepo_c "$REPO_DIR"
+    fi
+
+    # Upload public GPG key if it exists
+    if [ -f "leger-rpm-signing.public.asc" ]; then
+        echo -e "${YELLOW}Uploading GPG public key...${NC}"
+        s3_upload "leger-rpm-signing.public.asc" "fedora/repo.gpg"
+    fi
+
+    # Upload repository configuration file if it exists
+    if [ -f "packaging/leger.repo" ]; then
+        echo -e "${YELLOW}Uploading repository configuration...${NC}"
+        s3_upload "packaging/leger.repo" "fedora/leger.repo"
+    fi
+
+    # Upload everything to R2
+    echo -e "${YELLOW}Uploading repository to R2...${NC}"
+    s3_upload_dir "$REPO_DIR" "fedora"
+
+    echo ""
+    echo -e "${GREEN}=== Publishing complete! ===${NC}"
+    echo ""
+    echo "Repository URL: $PUBLIC_URL/fedora"
+    echo ""
+    echo "Users can install with:"
+    echo -e "${BLUE}sudo dnf config-manager --add-repo $PUBLIC_URL/fedora/leger.repo${NC}"
+    echo -e "${BLUE}sudo dnf install leger${NC}"
+    echo ""
+}
+
+# Parse arguments
+case "${1:-}" in
+    --help|-h)
+        echo "Usage: $0 [OPTIONS]"
+        echo ""
+        echo "Publish RPM packages to Cloudflare R2 bucket"
+        echo ""
+        echo "Required environment variables:"
+        echo "  R2_ACCESS_KEY_ID      - R2 access key"
+        echo "  R2_SECRET_ACCESS_KEY  - R2 secret key"
+        echo ""
+        echo "Optional environment variables:"
+        echo "  R2_BUCKET_NAME        - Bucket name (default: leger-packages)"
+        echo "  R2_ENDPOINT           - R2 endpoint URL"
+        echo "  PUBLIC_URL            - Public URL for repository (default: https://pkgs.leger.run)"
+        echo "  RPMS_DIR              - Directory containing RPMs (default: ./rpms)"
+        echo ""
+        echo "Example:"
+        echo "  export R2_ACCESS_KEY_ID=xxx"
+        echo "  export R2_SECRET_ACCESS_KEY=yyy"
+        echo "  export R2_ENDPOINT=https://account-id.r2.cloudflarestorage.com"
+        echo "  $0"
+        exit 0
+        ;;
+    *)
+        main "$@"
+        ;;
+esac


### PR DESCRIPTION
Implement automated RPM distribution system with GPG signing and Cloudflare R2 hosting for the Leger package repository.

## Infrastructure Components

**Scripts:**
- scripts/generate-gpg-key.sh - Generates GPG key pair for signing
- scripts/publish-rpm.sh - Publishes RPMs to R2 + generates repodata

**GitHub Actions:**
- Updated .github/workflows/release.yml:
  - Adds GPG signing step for all RPMs
  - Adds publish job to upload to R2 repository
  - Exports GPG public key for distribution

**Repository Configuration:**
- packaging/leger.repo - DNF repository configuration for end users

**Documentation:**
- docs/rpm-distribution-README.md - Overview and quick reference
- docs/rpm-distribution-setup.md - Complete setup guide
- docs/rpm-distribution-checklist.md - Step-by-step checklist

**Security:**
- Updated .gitignore to exclude GPG private keys
- All secrets managed via GitHub Secrets
- GPG signing enforced on all packages

## User Installation

Once configured, users can install with:
```bash
sudo dnf config-manager --add-repo https://pkgs.leger.run/fedora/leger.repo
sudo dnf install leger
```

## Next Steps

Manual configuration required:
1. Generate GPG key: ./scripts/generate-gpg-key.sh
2. Create Cloudflare R2 bucket
3. Configure custom domain (pkgs.leger.run)
4. Add GitHub secrets (GPG key, R2 credentials)

See docs/rpm-distribution-checklist.md for complete setup guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)