### PR TITLE
.github: pin GitHub actions (#142)

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -20,10 +20,10 @@ jobs:
         go-version: ['stable']
         os: ['ubuntu-latest']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Install Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
-    - uses: creachadair/go-presubmit-action@v2
+    - uses: creachadair/go-presubmit-action@4f7a734aa8275675a945fbf589734f8cf7dda58a # v2.0.3


### PR DESCRIPTION
Pins all GitHub actions to their latest versions in go-presubmit. Bumps checkout and setup up a major version as the main breaking change for both seems to be the node20 -> node24 bump.

Updates #cleanup