### PR TITLE
fix: use full GPG fingerprint for ownertrust import

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,9 +118,20 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-          # Trust the imported key
-          KEY_ID=$(gpg --list-keys --with-colons packages@leger.run | awk -F: '/^pub:/ {print $5}')
-          echo "${KEY_ID}:6:" | gpg --import-ownertrust
+
+          # FIXED: Get the full 40-character fingerprint, not just the key ID
+          FINGERPRINT=$(gpg --list-keys --with-colons packages@leger.run | awk -F: '/^fpr:/ {print $10; exit}')
+
+          if [ -z "$FINGERPRINT" ]; then
+            echo "ERROR: Could not extract fingerprint from imported key"
+            gpg --list-keys packages@leger.run
+            exit 1
+          fi
+
+          echo "Key fingerprint: $FINGERPRINT"
+
+          # Trust the imported key using full fingerprint
+          echo "${FINGERPRINT}:6:" | gpg --import-ownertrust
 
       - name: Sign RPM
         if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Modern GPG (2.2+) requires the full 40-character fingerprint for --import-ownertrust, not the 16-character key ID.

Changes:
- Extract fingerprint from 'fpr:' field instead of key ID from 'pub:' field
- Add validation to ensure fingerprint was extracted successfully
- Add debug output showing the fingerprint

This fixes the 'gpg: error in [stdin]: invalid fingerprint' error that occurred during GPG-signed RPM releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)