### PR TITLE
fix(rpm): reorganize repository with architecture-specific directories

### DIFF
--- a/packaging/leger.repo
+++ b/packaging/leger.repo
@@ -1,8 +1,8 @@
-[leger-stable]
-name=Leger Stable Repository
+[leger]
+name=Leger Packages
 baseurl=https://pkgs.leger.run/fedora/$basearch
 enabled=1
 gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://pkgs.leger.run/fedora/repo.gpg
-repo_gpgcheck=1
 metadata_expire=1h


### PR DESCRIPTION
Update RPM publishing to use proper DNF repository structure with $basearch (x86_64/aarch64) subdirectories instead of flat structure.

Changes:
- scripts/publish-rpm.sh: Organize RPMs into arch-specific directories
- packaging/leger.repo: Update repo ID and disable repo_gpgcheck

This fixes DNF installation issues where packages were not found because the repository structure didn't match $basearch expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)