### PR TITLE
fix(rpm): fix arithmetic expansion causing script exit

### DIFF
--- a/scripts/publish-rpm.sh
+++ b/scripts/publish-rpm.sh
@@ -67,17 +67,17 @@ for rpm in "${RPMS_DIR}"/*.rpm; do
         if [[ "$filename" == *"x86_64.rpm" ]]; then
             cp "$rpm" "${TEMP_DIR}/${REPO_ROOT}/x86_64/"
             echo "    → Copied to x86_64/"
-            ((rpm_count++))
+            rpm_count=$((rpm_count + 1))
         elif [[ "$filename" == *"aarch64.rpm" ]]; then
             cp "$rpm" "${TEMP_DIR}/${REPO_ROOT}/aarch64/"
             echo "    → Copied to aarch64/"
-            ((rpm_count++))
+            rpm_count=$((rpm_count + 1))
         elif [[ "$filename" == *"noarch.rpm" ]]; then
             # Copy noarch packages to both architectures
             cp "$rpm" "${TEMP_DIR}/${REPO_ROOT}/x86_64/"
             cp "$rpm" "${TEMP_DIR}/${REPO_ROOT}/aarch64/"
             echo "    → Copied to both architectures (noarch)"
-            ((rpm_count+=2))
+            rpm_count=$((rpm_count + 2))
         else
             echo "    ⚠️  Unknown architecture, skipping"
         fi


### PR DESCRIPTION
The script was failing with exit code 1 when incrementing rpm_count from 0 due to how bash handles post-increment with set -e:

- ((rpm_count++)) when rpm_count=0 returns old value (0)
- ((0)) evaluates to false, returning exit status 1
- set -e causes immediate script exit

Changed to rpm_count=$((rpm_count + 1)) which always succeeds since variable assignment returns exit status 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)