### PR TITLE
fix(tailscale): handle empty TailscaleIPs slice to prevent panic

### DIFF
--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -52,6 +52,10 @@ func (c *Client) GetIdentity(ctx context.Context) (*Identity, error) {
 		return nil, fmt.Errorf("not authenticated to Tailscale")
 	}
 
+	if len(status.Self.TailscaleIPs) == 0 {
+		return nil, fmt.Errorf("tailscale connected but no IP assigned (try: sudo tailscale up)")
+	}
+
 	user := status.User[status.Self.UserID]
 
 	return &Identity{


### PR DESCRIPTION
- Add validation to check TailscaleIPs has at least one element before accessing
- Return helpful error message when Tailscale is running but no IP assigned
- Fixes panic: 'index out of range [0] with length 0' in GetIdentity

Fixes the panic that occurs when Tailscale daemon is running but the device doesn't have an IP assigned yet (e.g., during initialization or after restart).