### PR TITLE
feat(auth): auto-open web app in browser after CLI login

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,26 @@
+package browser
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// Open opens the given URL in the user's default browser.
+// It returns an error if the browser cannot be opened.
+func Open(url string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	return cmd.Start()
+}

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1,0 +1,27 @@
+package browser
+
+import (
+	"testing"
+)
+
+// TestOpen verifies that Open returns an error for unsupported platforms
+// We can't easily test the actual browser opening in CI, so we test the error case
+func TestOpen(t *testing.T) {
+	// Test with a valid URL format
+	url := "https://app.leger.run/auth?token=test"
+
+	// This will attempt to open the browser
+	// We can't verify it actually opens, but we can ensure it doesn't panic
+	err := Open(url)
+
+	// On supported platforms (linux, darwin, windows), this should either:
+	// 1. Succeed (err == nil) if the browser command is available
+	// 2. Fail with a command not found error if the browser isn't available
+	// Both are acceptable in tests
+
+	// We only check that we don't get the "unsupported platform" error
+	// since we're running on a known platform
+	if err != nil && err.Error() == "unsupported platform: "+t.Name() {
+		t.Errorf("Got unsupported platform error on a supported platform")
+	}
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/leger-labs/leger/internal/auth"
+	"github.com/leger-labs/leger/internal/browser"
 	"github.com/leger-labs/leger/internal/legerrun"
 	"github.com/leger-labs/leger/internal/tailscale"
 	"github.com/leger-labs/leger/internal/ui"
@@ -122,6 +124,23 @@ For now, leger.run backend will accept any authenticated Tailscale user`)
 			fmt.Printf("  User UUID:     %s\n", storedAuth.UserUUID)
 			fmt.Printf("  Token expires: %s\n", storedAuth.ExpiresAt.Format(time.RFC3339))
 			fmt.Println()
+
+			// Open browser with token for web app authentication
+			webAuthURL := fmt.Sprintf("https://app.leger.run/auth?token=%s", url.QueryEscape(storedAuth.Token))
+
+			fmt.Println("Opening web app in browser...")
+			if err := browser.Open(webAuthURL); err != nil {
+				// Browser failed to open, provide manual URL
+				fmt.Println(ui.Warning("! Failed to open browser automatically"))
+				fmt.Println()
+				fmt.Println("To access the web UI, visit this URL:")
+				fmt.Println(ui.Success(webAuthURL))
+				fmt.Println()
+			} else {
+				fmt.Println(ui.Success("✓") + " Web app opened in browser")
+				fmt.Println()
+			}
+
 			fmt.Println("Next steps:")
 			fmt.Println("  - Manage secrets: leger secrets set <name> <value>")
 			fmt.Println("  - List secrets:   leger secrets list")


### PR DESCRIPTION
After successful CLI authentication, automatically open the user's default browser to https://app.leger.run/auth with the JWT token.

Changes:
- Add internal/browser package for cross-platform browser opening
- Update leger auth login to open browser with token after success
- Fallback to displaying URL if browser fails to open
- Support Linux (xdg-open), macOS (open), and Windows (cmd /c start)

This completes the frontend-CLI integration, allowing seamless authentication flow from CLI to web app.

Fixes: Frontend authentication handoff